### PR TITLE
Map connection tweaks

### DIFF
--- a/agent/nodes/should_critique/node.py
+++ b/agent/nodes/should_critique/node.py
@@ -19,11 +19,15 @@ class ShouldCritiqueNode(Node[AgentStore]):
 
         state = await store.get_state()
 
+        if state.handler is None:
+            raise ValueError("Handler is not set.")
+
         service = ShouldCritiqueService(
             iteration=state.iteration,
             raw_memory=state.raw_memory,
             goals=state.goals,
             iterations_since_last_critique=state.iterations_since_last_critique,
+            handler=state.handler,
         )
         should_critique = await service.check_should_critique()
 

--- a/agent/nodes/should_critique/service.py
+++ b/agent/nodes/should_critique/service.py
@@ -1,5 +1,6 @@
 from loguru import logger
 
+from agent.enums import AgentStateHandler
 from agent.nodes.should_critique.prompts import SHOULD_CRITIQUE_PROMPT
 from agent.nodes.should_critique.schemas import ShouldCritiqueResponse
 from common.constants import (
@@ -23,16 +24,20 @@ class ShouldCritiqueService:
         raw_memory: RawMemory,
         goals: Goals,
         iterations_since_last_critique: int,
+        handler: AgentStateHandler,
     ) -> None:
         self.iteration = iteration
         self.raw_memory = raw_memory
         self.goals = goals
         self.iterations_since_last_critique = iterations_since_last_critique
+        self.handler = handler
 
     async def check_should_critique(self) -> bool:
         """Check if the agent should critique by looking for loops in the raw memory."""
         if (
-            self.iteration % ITERATIONS_PER_GENERIC_CRITIQUE_CHECK != 0
+            # The Overworld Handler has its own critique prompt with map-specific information.
+            self.handler == AgentStateHandler.OVERWORLD
+            or self.iteration % ITERATIONS_PER_GENERIC_CRITIQUE_CHECK != 0
             or self.iterations_since_last_critique < MIN_ITERATIONS_PER_CRITIQUE
         ):
             return False

--- a/agent/subflows/overworld_handler/nodes/critique/prompts.py
+++ b/agent/subflows/overworld_handler/nodes/critique/prompts.py
@@ -12,6 +12,7 @@ Common sources of error include (but are not limited to):
 - Not taking advantage of your available tools to help you with more complex tasks
 - Not exploring the game world enough, especially the current map. If this is the case, you should point out exactly where you should be exploring. If you can't seem to find a valid path in one direction, is there unexplored terrain in another direction that you can try? Are there warp tiles that you can use to get to a new map?
 - Trying to access a location that you are not able to access at the moment, or have not yet found a way to get to. Are there warp tiles that you haven't explored yet? Are there exploration candidates on the current map that you haven't visited yet? Do you perhaps need to go through a building or cave to get there?
+- Failing to interact with NPCs or objects that could give you information or items.
 - Thinking that you are unable to act or move. You almost certainly can. There are no cutscenes or invisible walls or traps that lock the player indefinitely. If you are in the overworld, you can always move.
 - Doing the same thing over and over again and expecting different results. If you are walking in circles, try doing something completely different. Go to a new area. Anything to break out of the cycle.
 

--- a/agent/subflows/overworld_handler/nodes/critique/prompts.py
+++ b/agent/subflows/overworld_handler/nodes/critique/prompts.py
@@ -11,6 +11,7 @@ Common sources of error include (but are not limited to):
 - Making false assumptions and failing to correct them. This includes in past critiques. Do not be afraid to correct your own past mistakes, even if those mistakes came from the critic model.
 - Not taking advantage of your available tools to help you with more complex tasks
 - Not exploring the game world enough, especially the current map. If this is the case, you should point out exactly where you should be exploring. If you can't seem to find a valid path in one direction, is there unexplored terrain in another direction that you can try? Are there warp tiles that you can use to get to a new map?
+- Trying to access a location that you are not able to access at the moment, or have not yet found a way to get to. Are there warp tiles that you haven't explored yet? Are there exploration candidates on the current map that you haven't visited yet? Do you perhaps need to go through a building or cave to get there?
 - Thinking that you are unable to act or move. You almost certainly can. There are no cutscenes or invisible walls or traps that lock the player indefinitely. If you are in the overworld, you can always move.
 - Doing the same thing over and over again and expecting different results. If you are walking in circles, try doing something completely different. Go to a new area. Anything to break out of the cycle.
 

--- a/agent/subflows/overworld_handler/nodes/navigate/formatting.py
+++ b/agent/subflows/overworld_handler/nodes/navigate/formatting.py
@@ -79,7 +79,9 @@ def format_map_boundary_tiles(
         elif connection is not None:
             output.append(
                 f"You have not yet discovered a valid path to the {connection.name} map"
-                f" boundary at the far {cardinal_dir} of the current map."
+                f" boundary at the far {cardinal_dir} of the current map. You can likely find it"
+                f" either by visiting more exploration candidates, or perhaps by accessing it via"
+                f" an intermediate map (e.g. through a building or cave)."
             )
 
     return "\n".join(output)

--- a/emulator/emulator.py
+++ b/emulator/emulator.py
@@ -79,7 +79,10 @@ class YellowLegacyEmulator(AbstractAsyncContextManager):
                 if not self._tick():
                     self.stop()
                     break
-            await asyncio.sleep(0.001)  # Pass control back to the event loop.
+            # Pass control back to the event loop. Making this time too large will cause audio to
+            # stutter, but making it too small can corrupt save states by not giving the emulator
+            # enough time to save the state. This value seems to work well.
+            await asyncio.sleep(0.002)
 
     def stop(self) -> None:
         """Stop the emulator."""

--- a/emulator/emulator.py
+++ b/emulator/emulator.py
@@ -37,8 +37,12 @@ class YellowLegacyEmulator(AbstractAsyncContextManager):
         window = "null" if headless else "SDL2"
         self._pyboy = PyBoy(rom_path, sound_volume=volume, window=window)
 
+        # This load_state piece is technically blocking, but it's only done once at initialization,
+        # so there's nothing for it to block.
         if save_state:
-            self._pyboy.load_state(io.BytesIO(base64.b64decode(save_state)))
+            buffer = io.BytesIO(base64.b64decode(save_state))
+            buffer.seek(0)  # Pyboy requires this.
+            self._pyboy.load_state(buffer)
         elif save_state_path:
             with save_state_path.open("rb") as f:
                 self._pyboy.load_state(f)

--- a/overworld_map/schemas.py
+++ b/overworld_map/schemas.py
@@ -280,13 +280,20 @@ class OverworldMap(BaseModel):
             )
         out = ""
         for direction, connection in [
-            ("north", self.north_connection),
-            ("south", self.south_connection),
-            ("east", self.east_connection),
-            ("west", self.west_connection),
+            ("NORTH", self.north_connection),
+            ("SOUTH", self.south_connection),
+            ("EAST", self.east_connection),
+            ("WEST", self.west_connection),
         ]:
             if connection is not None:
-                out += f"The map to the {direction} is {connection.name}.\n"
+                out += f"- The map to the {direction} is {connection.name}.\n"
             else:
-                out += f"There is no map connection to the {direction}.\n"
+                out += f"- There is no map connection to the {direction}.\n"
+        out += (
+            "Important: The fact that you are aware of a map connection does not necessarily mean"
+            " that you can access it. If the navigation tool is unable to find a valid path to a"
+            " given map connection, it means that you cannot access it from your current position."
+            " You either need to explore more of the current map to find it, or you must access it"
+            " via another map in between (e.g. through a building or cave)."
+        )
         return out.strip()


### PR DESCRIPTION
A handful of small tweaks:
* Add a bit more info to map connections so the AI isn't confused when it can't reach them
* Don't use the generic critique in the overworld. Use the specific tool instead since it has the map info
* Hopefully fixed the issue that keeps corrupting my save states?