### PR TITLE
Misc tweaks from playtesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ Longer answer based on recent runs:
 
 - The workflow completes roughly 370 iterations per hour.
 - Instructions, screenshots, game state, tool calls, results, and model output account for ~5,600 tokens per iteration.
-- Rolling memory grows logarithmically, contributing roughly `2,800 + 400 × log₂ N` tokens to iteration N.
+- Rolling memory grows logarithmically with iterations, contributing roughly `2,800 + 400 × log₂ N` tokens to iteration `N`.
 
-Together, that is around `8,400 + 400 × log₂ N` tokens per iteration. Applying Luna's current prices to that token mix at 370 iterations per hour gives hourly cost growth of:
+Together, that is around `8,400 + 400 × log₂ N` tokens per iteration. Since `N ≈ 370H` after `H` hours of play, applying Luna's current prices to that token mix and expressing the result in hours gives approximately:
 
-`hourly cost ≈ $0.47 + $0.026 × log₂ N`
+`hourly cost ≈ $0.69 + $0.026 × log₂ H`
 
 The $1 headline is a nice round number for a run that has been progressing for a while.
 

--- a/agent/battle/agent.py
+++ b/agent/battle/agent.py
@@ -65,6 +65,8 @@ async def run_battle(context: AgentContext) -> None:
                 current_node = node
                 node = await agent_run.next(node)
                 if isinstance(current_node, CallToolsNode):
+                    if context.consume_control_handoff():
+                        break
                     await context.complete_iteration()
                     game_state = await context.emulator.get_game_state()
                     if not is_battle_handler_state(game_state):

--- a/agent/battle/formatting.py
+++ b/agent/battle/formatting.py
@@ -39,12 +39,7 @@ def format_battle_info(game_state: GameState) -> str:
         out += "</player_pokemon>\n"
 
     if battle.enemy_pokemon:
-        out += "<enemy_pokemon>\n"
-        out += f"Name: {battle.enemy_pokemon.name}\n"
-        out += f"Level: {battle.enemy_pokemon.level}\n"
-        out += f"HP Percentage: {battle.enemy_pokemon.hp_pct:.0f}%\n"
-        out += f"Status Ailment: {battle.enemy_pokemon.status}\n"
-        out += "</enemy_pokemon>\n"
+        out += _format_enemy_pokemon(game_state)
 
     if battle.num_enemy_pokemon:
         out += (
@@ -53,6 +48,27 @@ def format_battle_info(game_state: GameState) -> str:
         )
 
     out += "</battle_info>"
+    return out
+
+
+def _format_enemy_pokemon(game_state: GameState) -> str:
+    """Format the current opposing Pokemon."""
+    battle = game_state.battle
+    enemy_pokemon = battle.enemy_pokemon
+    if enemy_pokemon is None:
+        return ""
+
+    out = "<enemy_pokemon>\n"
+    out += f"Name: {enemy_pokemon.name}\n"
+    if (
+        battle.battle_type in {BattleType.WILD, BattleType.SAFARI_ZONE}
+        and enemy_pokemon.pokedex_number in game_state.player.pokedex_caught
+    ):
+        out += "Pokedex: This species is already registered as caught.\n"
+    out += f"Level: {enemy_pokemon.level}\n"
+    out += f"HP Percentage: {enemy_pokemon.hp_pct:.0f}%\n"
+    out += f"Status Ailment: {enemy_pokemon.status}\n"
+    out += "</enemy_pokemon>\n"
     return out
 
 

--- a/agent/context.py
+++ b/agent/context.py
@@ -25,6 +25,12 @@ class AgentContext:
         repr=False,
         compare=False,
     )
+    _control_handoff_requested: bool = field(
+        default=False,
+        init=False,
+        repr=False,
+        compare=False,
+    )
 
     async def add_llm_usage(self, tokens: int, cost: float) -> None:
         """Add one LLM response's usage to the shared state."""
@@ -34,9 +40,20 @@ class AgentContext:
 
     async def begin_iteration(self) -> None:
         """Prepare memory for one top-level handler activation."""
+        self._control_handoff_requested = False
         rolling_memory = await initialize_memory(self.state.rolling_memory.current_block)
         self.state.rolling_memory = rolling_memory
         self.state.iteration = rolling_memory.current_block.iteration
+
+    def request_control_handoff(self) -> None:
+        """Request a normal return to the gameplay dispatcher after tool execution."""
+        self._control_handoff_requested = True
+
+    def consume_control_handoff(self) -> bool:
+        """Consume and clear a pending request to return to the gameplay dispatcher."""
+        requested = self._control_handoff_requested
+        self._control_handoff_requested = False
+        return requested
 
     async def complete_iteration(self) -> None:
         """Finalize the current block and advance the live iteration state."""

--- a/agent/formatting/game_state.py
+++ b/agent/formatting/game_state.py
@@ -33,11 +33,12 @@ def format_party_info(game_state: GameState) -> str:
 
 def format_inventory_info(game_state: GameState) -> str:
     """Format the player's current inventory for agent prompts."""
-    if not game_state.inventory.items:
-        return ""
     out = "<inventory>\n"
-    for item in game_state.inventory.items:
-        out += f"- {item.name} (x{item.quantity})\n"
+    if game_state.inventory.items:
+        for index, item in enumerate(game_state.inventory.items):
+            out += f"[{index}] {item.name} (x{item.quantity})\n"
+    else:
+        out += "Your inventory is empty.\n"
     out += "</inventory>"
     return out
 

--- a/agent/formatting/memory.py
+++ b/agent/formatting/memory.py
@@ -21,8 +21,10 @@ def format_goals(goals: Goals) -> str:
     out += (
         "Here are the goals that you have set for yourself. Your ultimate goal is, of course,"
         " to collect all eight badges and become the Elite Four Champion, but these goals here"
-        " are the next steps on your journey to that goal. The actions that you take and the"
-        " thoughts that you think should all be in service of these goals."
+        " are the next steps on your journey to that goal. Your primary goal is one major"
+        " outcome, while each secondary goal is one discrete step that directly supports it."
+        " The actions that you take and the thoughts that you think should all be in service"
+        " of these goals."
     )
     out += "\n<goals>\n"
     if goals.goals:
@@ -55,9 +57,9 @@ def format_rolling_memory(memory: RollingMemory) -> str:
 
 
 def _format_goal(goal: Goal) -> str:
-    """Format one goal with its role."""
-    role = "Primary goal" if goal.is_primary else "Other goal"
-    return f"{role}: {goal.goal}"
+    """Format one goal with its role and most recent revision iteration."""
+    role = "Primary goal" if goal.is_primary else "Secondary goal"
+    return f"{role} (last updated at iteration {goal.updated_at_iteration}): {goal.goal}"
 
 
 def _format_memory_entry(entry: _MemoryEntry) -> str:

--- a/agent/formatting/memory.py
+++ b/agent/formatting/memory.py
@@ -31,6 +31,8 @@ def format_goals(goals: Goals) -> str:
         out += "\n".join(
             f"[{index}] {_format_goal(goal)}" for index, goal in enumerate(goals.goals)
         )
+        if not any(not goal.is_primary for goal in goals.goals):
+            out += "\nYou have not set any secondary goals yet."
     else:
         out += "You have not set any goals yet."
     out += "\n</goals>\n"

--- a/agent/formatting/memory.py
+++ b/agent/formatting/memory.py
@@ -28,9 +28,7 @@ def format_goals(goals: Goals) -> str:
         " development, healing or resupplying, or investigating something you discovered. Do"
         " not use goals for individual button presses or routine movement. Goals must come from"
         " current structured information, observed game text, or recorded memory, never from"
-        " assumptions about future game progression or general Pokemon knowledge. Regularly"
-        " reflect on what you are trying to accomplish and use the goal tools to keep this list"
-        " useful and current."
+        " assumptions about future game progression or general Pokemon knowledge."
     )
     out += "\n<goals>\n"
     if goals.goals:

--- a/agent/formatting/memory.py
+++ b/agent/formatting/memory.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING
 
+from memory.goals import MAX_GOALS
 from memory.rolling_memory.schemas import (
     CurrentMemoryBlock,
     MemorySummary,
@@ -10,7 +11,7 @@ from memory.rolling_memory.schemas import (
 )
 
 if TYPE_CHECKING:
-    from memory.goals import Goal, Goals
+    from memory.goals import Goals
 
 type _MemoryEntry = CurrentMemoryBlock | RawMemoryBlock | MemorySummary
 
@@ -19,22 +20,26 @@ def format_goals(goals: Goals) -> str:
     """Format the agent's current goals for gameplay prompts."""
     out = "<goals_info>\n"
     out += (
-        "Here are the goals that you have set for yourself. Your primary goal is one major"
-        " outcome established by your current context, while each secondary goal is one"
-        " discrete step that directly supports it. Goals must come from current structured"
-        " information, observed game text, or recorded memory, never from assumptions about"
-        " future game progression or general Pokemon knowledge. The actions that you take and"
-        " the thoughts that you think should all be in service of these goals."
+        f"Here are the goals that you have set for yourself. You can keep up to {MAX_GOALS} goals"
+        " at once. Goals are current objectives or concerns that should influence your decisions"
+        " until they are resolved. A goal can be short-term or long-term; what matters is that"
+        " forgetting it could lead to worse decisions. When several priorities are active,"
+        " record each separately. Goals can concern progression through the current area, team"
+        " development, healing or resupplying, or investigating something you discovered. Do"
+        " not use goals for individual button presses or routine movement. Goals must come from"
+        " current structured information, observed game text, or recorded memory, never from"
+        " assumptions about future game progression or general Pokemon knowledge. Regularly"
+        " reflect on what you are trying to accomplish and use the goal tools to keep this list"
+        " useful and current."
     )
     out += "\n<goals>\n"
     if goals.goals:
         out += "\n".join(
-            f"[{index}] {_format_goal(goal)}" for index, goal in enumerate(goals.goals)
+            f"[{i}] {g.goal} (last updated at iteration {g.updated_at_iteration})"
+            for i, g in enumerate(goals.goals)
         )
-        if not any(not goal.is_primary for goal in goals.goals):
-            out += "\nYou have not set any secondary goals yet."
     else:
-        out += "You have not set any goals yet."
+        out += "You don't have any active goals. You should have at least one."
     out += "\n</goals>\n"
     out += "</goals_info>"
     return out
@@ -56,12 +61,6 @@ def format_rolling_memory(memory: RollingMemory) -> str:
         "each iteration takes a couple of seconds.\n"
         "<memory>\n" + "\n".join(_format_memory_entry(entry) for entry in entries) + "\n</memory>"
     )
-
-
-def _format_goal(goal: Goal) -> str:
-    """Format one goal with its role and most recent revision iteration."""
-    role = "Primary goal" if goal.is_primary else "Secondary goal"
-    return f"{role} (last updated at iteration {goal.updated_at_iteration}): {goal.goal}"
 
 
 def _format_memory_entry(entry: _MemoryEntry) -> str:

--- a/agent/formatting/memory.py
+++ b/agent/formatting/memory.py
@@ -19,12 +19,12 @@ def format_goals(goals: Goals) -> str:
     """Format the agent's current goals for gameplay prompts."""
     out = "<goals_info>\n"
     out += (
-        "Here are the goals that you have set for yourself. Your ultimate goal is, of course,"
-        " to collect all eight badges and become the Elite Four Champion, but these goals here"
-        " are the next steps on your journey to that goal. Your primary goal is one major"
-        " outcome, while each secondary goal is one discrete step that directly supports it."
-        " The actions that you take and the thoughts that you think should all be in service"
-        " of these goals."
+        "Here are the goals that you have set for yourself. Your primary goal is one major"
+        " outcome established by your current context, while each secondary goal is one"
+        " discrete step that directly supports it. Goals must come from current structured"
+        " information, observed game text, or recorded memory, never from assumptions about"
+        " future game progression or general Pokemon knowledge. The actions that you take and"
+        " the thoughts that you think should all be in service of these goals."
     )
     out += "\n<goals>\n"
     if goals.goals:

--- a/agent/overworld/agent.py
+++ b/agent/overworld/agent.py
@@ -93,6 +93,8 @@ async def run_overworld(
                 current_node = node
                 node = await agent_run.next(node)
                 if isinstance(current_node, CallToolsNode):
+                    if context.consume_control_handoff():
+                        break
                     await context.complete_iteration()
                     (
                         game_state,

--- a/agent/overworld/agent.py
+++ b/agent/overworld/agent.py
@@ -8,6 +8,7 @@ from pydantic_ai.models.openai import OpenAIResponsesModelSettings
 from pydantic_graph import End
 
 from agent.context import AgentContext
+from agent.overworld.map_view import CurrentMapView, build_current_map_view
 from agent.overworld.prompts import build_overworld_decision_prompt
 from agent.overworld.tools.registry import build_overworld_toolset
 from agent.utils import (
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
 def build_overworld_agent(
     context: AgentContext,
     current_map: OverworldMap,
+    map_view: CurrentMapView,
     game_state: GameState,
 ) -> Agent[AgentContext, str]:
     """Construct the Pydantic AI overworld agent."""
@@ -42,6 +44,7 @@ def build_overworld_agent(
             build_overworld_toolset(
                 context,
                 current_map,
+                map_view,
                 game_state,
             ),
         ],
@@ -68,16 +71,18 @@ async def run_overworld(
     if not is_overworld_handler_state(initial_game_state, initial_boundary):
         return
     current_map = await prepare_overworld_map(context.state.iteration, initial_game_state)
+    map_view = build_current_map_view(current_map, initial_game_state)
     agent = build_overworld_agent(
         context,
         current_map,
+        map_view,
         initial_game_state,
     )
     try:
         async with agent.iter(
             build_overworld_agent_input(
                 context,
-                current_map,
+                map_view,
                 initial_game_state=initial_game_state,
                 initial_screenshot=initial_screenshot,
             ),
@@ -108,7 +113,7 @@ async def run_overworld(
 
 def build_overworld_agent_input(
     context: AgentContext,
-    current_map: OverworldMap,
+    map_view: CurrentMapView,
     *,
     initial_game_state: GameState,
     initial_screenshot: Image.Image,
@@ -118,7 +123,7 @@ def build_overworld_agent_input(
         build_screenshot_content(initial_screenshot),
         build_overworld_decision_prompt(
             context,
-            current_map,
+            map_view,
             initial_game_state,
         ),
     ]

--- a/agent/overworld/formatting.py
+++ b/agent/overworld/formatting.py
@@ -32,6 +32,41 @@ _ALWAYS_VISIBLE_TILES = {
     AsciiTile.SIGN,
 }
 
+# These buildings are visually identifiable from their exterior before the player enters them, so
+# revealing their destination does not give the agent information unavailable on the game screen.
+_VISIBLE_UNVISITED_DESTINATIONS = frozenset(
+    {
+        MapId.VIRIDIAN_POKECENTER,
+        MapId.PEWTER_POKECENTER,
+        MapId.CERULEAN_POKECENTER,
+        MapId.MT_MOON_POKECENTER,
+        MapId.ROCK_TUNNEL_POKECENTER,
+        MapId.VERMILION_POKECENTER,
+        MapId.CELADON_POKECENTER,
+        MapId.LAVENDER_POKECENTER,
+        MapId.FUCHSIA_POKECENTER,
+        MapId.CINNABAR_POKECENTER,
+        MapId.SAFFRON_POKECENTER,
+        MapId.VIRIDIAN_GYM,
+        MapId.PEWTER_GYM,
+        MapId.CERULEAN_GYM,
+        MapId.VERMILION_GYM,
+        MapId.CELADON_GYM,
+        MapId.FUCHSIA_GYM,
+        MapId.CINNABAR_GYM,
+        MapId.SAFFRON_GYM,
+        MapId.VIRIDIAN_MART,
+        MapId.PEWTER_MART,
+        MapId.CERULEAN_MART,
+        MapId.VERMILION_MART,
+        MapId.CELADON_MART_1F,
+        MapId.LAVENDER_MART,
+        MapId.FUCHSIA_MART,
+        MapId.CINNABAR_MART,
+        MapId.SAFFRON_MART,
+    }
+)
+
 
 def format_explored_percentage(current_map: OverworldMap) -> str:
     """Format the portion of the map that has been explored."""
@@ -65,7 +100,11 @@ def _format_overworld_warp(
     player_coords: Coords,
 ) -> str:
     """Format a known overworld warp for the agent."""
-    if warp.destination in known_map_ids or warp.destination in {MapId.OUTSIDE, MapId.UNKNOWN}:
+    if (
+        warp.destination in known_map_ids
+        or warp.destination in {MapId.OUTSIDE, MapId.UNKNOWN}
+        or warp.destination in _VISIBLE_UNVISITED_DESTINATIONS
+    ):
         destination = warp.destination.name
         if warp.destination_coords is not None:
             destination += f" at {warp.destination_coords}"

--- a/agent/overworld/formatting.py
+++ b/agent/overworld/formatting.py
@@ -10,8 +10,9 @@ from common.enums import AsciiTile, BlockedDirection, FacingDirection, MapId, Wa
 from common.schemas import Coords
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
+    from agent.overworld.map_view import CurrentMapView
     from emulator.game_state import GameState
     from emulator.parsers.sign import Sign
     from emulator.parsers.sprite import Sprite
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
     from overworld_map.schemas import OverworldMap
 
 _ALWAYS_VISIBLE_TILES = {
+    AsciiTile.OUTSIDE_REGION,
     AsciiTile.UNSEEN,
     AsciiTile.WALL,
     AsciiTile.WATER,
@@ -66,12 +68,6 @@ _VISIBLE_UNVISITED_DESTINATIONS = frozenset(
         MapId.SAFFRON_MART,
     }
 )
-
-
-def format_explored_percentage(current_map: OverworldMap) -> str:
-    """Format the portion of the map that has been explored."""
-    explored = np.mean(current_map.terrain_ndarray != AsciiTile.UNSEEN)
-    return f"{explored:.0%}"
 
 
 def _format_overworld_sprite(sprite: Sprite, map_id: MapId) -> str:
@@ -134,11 +130,13 @@ def _get_warp_description(warp: Warp, player_coords: Coords) -> str:
 
 
 def format_legend(
-    current_map: OverworldMap,
+    map_view: CurrentMapView,
     legend: Mapping[AsciiTile, str],
 ) -> str:
     """Format the legend for the tile types present on the map."""
-    tiles = {AsciiTile(tile) for row in current_map.terrain for tile in row} | _ALWAYS_VISIBLE_TILES
+    tiles = {
+        AsciiTile(tile) for row in map_view.display_tiles for tile in row
+    } | _ALWAYS_VISIBLE_TILES
     return "\n".join(f'- "{tile}": {legend[tile]}' for tile in AsciiTile if tile in tiles)
 
 
@@ -179,22 +177,23 @@ def get_tile_notes(
     return tile, blocked_text
 
 
-def format_sprite_notes(current_map: OverworldMap, game_state: GameState) -> str:
+def format_sprite_notes(map_view: CurrentMapView, game_state: GameState) -> str:
     """Format known sprites in index order."""
+    current_map = map_view.overworld_map
     output = ""
     sprites = [
         game_state.sprites[entity_id]
         for entity_id in sorted(current_map.known_sprite_ids)
         if entity_id in game_state.sprites
+        and _is_relevant_coords(game_state.sprites[entity_id].coords, map_view, game_state)
     ]
-    if np.isin(AsciiTile.PC_TILE, current_map.terrain_ndarray):
+    pc_locations = np.argwhere(current_map.terrain_ndarray == AsciiTile.PC_TILE)
+    if len(pc_locations) > 0:
         # This is a bit of a hack, but the model really struggles to find the PC otherwise.
-        location = np.argwhere(current_map.terrain_ndarray == AsciiTile.PC_TILE)[0]
-        output += (
-            f"- There is a PC at {Coords(row=int(location[0]), col=int(location[1]))}. It can only"
-            " be interacted with from below.\n"
-        )
-    elif not sprites:
+        location = Coords(row=int(pc_locations[0][0]), col=int(pc_locations[0][1]))
+        if _is_relevant_coords(location, map_view, game_state):
+            output += f"- There is a PC at {location}. It can only be interacted with from below.\n"
+    if not output and not sprites:
         return "No sprites discovered."
     output += "\n".join(
         f"- {_format_overworld_sprite(sprite, current_map.id)}" for sprite in sprites
@@ -202,12 +201,14 @@ def format_sprite_notes(current_map: OverworldMap, game_state: GameState) -> str
     return output.strip()
 
 
-def format_warp_notes(current_map: OverworldMap, game_state: GameState) -> str:
+def format_warp_notes(map_view: CurrentMapView, game_state: GameState) -> str:
     """Format known warps in index order."""
+    current_map = map_view.overworld_map
     warps = [
         game_state.warps[entity_id]
         for entity_id in sorted(current_map.known_warp_ids)
         if entity_id in game_state.warps
+        and _is_relevant_coords(game_state.warps[entity_id].coords, map_view, game_state)
     ]
     if not warps:
         return "No warp tiles discovered."
@@ -223,53 +224,60 @@ def format_warp_notes(current_map: OverworldMap, game_state: GameState) -> str:
     )
 
 
-def format_sign_notes(current_map: OverworldMap, game_state: GameState) -> str:
+def format_sign_notes(map_view: CurrentMapView, game_state: GameState) -> str:
     """Format known signs in index order."""
+    current_map = map_view.overworld_map
     signs = [
         game_state.signs[entity_id]
         for entity_id in sorted(current_map.known_sign_ids)
         if entity_id in game_state.signs
+        and _is_relevant_coords(game_state.signs[entity_id].coords, map_view, game_state)
     ]
     if not signs:
         return "No signs discovered."
     return "\n".join(f"- {_format_overworld_sign(sign, current_map.id)}" for sign in signs)
 
 
-def format_connection_notes(current_map: OverworldMap) -> str:
-    """Format direct map connections and navigation guidance."""
-    if (
-        not current_map.north_connection
-        and not current_map.south_connection
-        and not current_map.east_connection
-        and not current_map.west_connection
-    ):
+def format_connection_notes(map_view: CurrentMapView) -> str:
+    """Format direct map connections reachable from the current region."""
+    current_map = map_view.overworld_map
+    connections = [
+        ("NORTH", FacingDirection.UP, current_map.north_connection),
+        ("SOUTH", FacingDirection.DOWN, current_map.south_connection),
+        ("EAST", FacingDirection.RIGHT, current_map.east_connection),
+        ("WEST", FacingDirection.LEFT, current_map.west_connection),
+    ]
+    reachable_connections = [
+        (direction, connection)
+        for direction, facing, connection in connections
+        if connection is not None and map_view.boundary_tiles[facing]
+    ]
+    if not reachable_connections:
         return (
-            "There are no direct connections to other maps on this map. The only way to leave"
-            " this map is via warp tiles."
+            "There are no direct connections to other maps reachable from your current region."
+            " Leave it through a reachable warp or expand it by exploring unseen terrain."
         )
-    output = ""
-    for direction, connection in [
-        ("NORTH", current_map.north_connection),
-        ("SOUTH", current_map.south_connection),
-        ("EAST", current_map.east_connection),
-        ("WEST", current_map.west_connection),
-    ]:
-        if connection is not None:
-            output += f"- The map to the {direction} is {connection.destination_map.name}.\n"
-        else:
-            output += f"- There is no map connection to the {direction}.\n"
-    output += (
-        "Important: The fact that you are aware of a map connection does not necessarily mean"
-        " that you can access it. If the navigation tool is unable to find a valid path to a"
-        " given map connection, it means that you cannot access it from your current position."
-        " You either need to explore more of the current map to find it, or you must get to"
-        " another part of the current map to access it via an intermediate map (e.g. through"
-        " a building or cave)."
+    return "\n".join(
+        f"- The map to the {direction} is {connection.destination_map.name}."
+        for direction, connection in reachable_connections
     )
-    return output.strip()
 
 
-def format_coordinates_grid(coordinates: list[Coords], map_data: OverworldMap) -> str:
+def _is_relevant_coords(
+    coords: Coords,
+    map_view: CurrentMapView,
+    game_state: GameState,
+) -> bool:
+    """Return whether coordinates belong to the region or the current visible screen."""
+    return (
+        coords in map_view.visible_coords or game_state.screen.to_screen_coords(coords) is not None
+    )
+
+
+def format_coordinates_grid(
+    coordinates: Sequence[Coords],
+    map_data: OverworldMap,
+) -> str:
     """Format coordinates and their tile types as a grid."""
     if not coordinates:
         return ""
@@ -286,7 +294,7 @@ def format_coordinates_grid(coordinates: list[Coords], map_data: OverworldMap) -
 
 
 def format_exploration_candidates(
-    candidates: list[Coords],
+    candidates: Sequence[Coords],
     map_data: OverworldMap,
 ) -> str:
     """Format exploration candidates for the overworld agent."""
@@ -296,7 +304,7 @@ def format_exploration_candidates(
 
 
 def format_map_boundary_tiles(
-    boundary_tiles: dict[FacingDirection, list[Coords]],
+    boundary_tiles: Mapping[FacingDirection, Sequence[Coords]],
     map_data: OverworldMap,
 ) -> str:
     """Format accessible map boundaries for the overworld agent."""
@@ -315,13 +323,4 @@ def format_map_boundary_tiles(
                 f"The {connection.destination_map.name} map boundary at the far {cardinal_dir}"
                 f" of the current map is accessible from {coord_str}.",
             )
-        elif connection is not None:
-            output.append(
-                "You have not yet discovered a valid path to the"
-                f" {connection.destination_map.name} map boundary at the far {cardinal_dir} of the"
-                f" current map. You can likely find it either by visiting more exploration"
-                f" candidates, or perhaps by getting to a new part of the current map via an"
-                f" intermediate map (e.g. through a building or cave).",
-            )
-
-    return "\n".join(output)
+    return "\n".join(output) or "No connected-map boundary is reachable from this region."

--- a/agent/overworld/formatting.py
+++ b/agent/overworld/formatting.py
@@ -181,17 +181,22 @@ def format_sprite_notes(map_view: CurrentMapView, game_state: GameState) -> str:
     """Format known sprites in index order."""
     current_map = map_view.overworld_map
     output = ""
+    # Some sprites (e.g. Nurses) remain interactable across counters even though their tiles are
+    # outside the player's connected region.
     sprites = [
         game_state.sprites[entity_id]
         for entity_id in sorted(current_map.known_sprite_ids)
         if entity_id in game_state.sprites
-        and _is_relevant_coords(game_state.sprites[entity_id].coords, map_view, game_state)
+        and (
+            game_state.sprites[entity_id].coords in map_view.visible_coords
+            or game_state.screen.to_screen_coords(game_state.sprites[entity_id].coords) is not None
+        )
     ]
     pc_locations = np.argwhere(current_map.terrain_ndarray == AsciiTile.PC_TILE)
     if len(pc_locations) > 0:
         # This is a bit of a hack, but the model really struggles to find the PC otherwise.
         location = Coords(row=int(pc_locations[0][0]), col=int(pc_locations[0][1]))
-        if _is_relevant_coords(location, map_view, game_state):
+        if location in map_view.visible_coords:
             output += f"- There is a PC at {location}. It can only be interacted with from below.\n"
     if not output and not sprites:
         return "No sprites discovered."
@@ -208,7 +213,7 @@ def format_warp_notes(map_view: CurrentMapView, game_state: GameState) -> str:
         game_state.warps[entity_id]
         for entity_id in sorted(current_map.known_warp_ids)
         if entity_id in game_state.warps
-        and _is_relevant_coords(game_state.warps[entity_id].coords, map_view, game_state)
+        and game_state.warps[entity_id].coords in map_view.visible_coords
     ]
     if not warps:
         return "No warp tiles discovered."
@@ -231,7 +236,7 @@ def format_sign_notes(map_view: CurrentMapView, game_state: GameState) -> str:
         game_state.signs[entity_id]
         for entity_id in sorted(current_map.known_sign_ids)
         if entity_id in game_state.signs
-        and _is_relevant_coords(game_state.signs[entity_id].coords, map_view, game_state)
+        and game_state.signs[entity_id].coords in map_view.visible_coords
     ]
     if not signs:
         return "No signs discovered."
@@ -260,17 +265,6 @@ def format_connection_notes(map_view: CurrentMapView) -> str:
     return "\n".join(
         f"- The map to the {direction} is {connection.destination_map.name}."
         for direction, connection in reachable_connections
-    )
-
-
-def _is_relevant_coords(
-    coords: Coords,
-    map_view: CurrentMapView,
-    game_state: GameState,
-) -> bool:
-    """Return whether coordinates belong to the region or the current visible screen."""
-    return (
-        coords in map_view.visible_coords or game_state.screen.to_screen_coords(coords) is not None
     )
 
 

--- a/agent/overworld/map_view.py
+++ b/agent/overworld/map_view.py
@@ -7,11 +7,11 @@ import numpy as np
 
 from agent.overworld import navigation
 from common.enums import AsciiTile
+from common.schemas import Coords
 from overworld_map.views import get_current_map_tiles
 
 if TYPE_CHECKING:
     from common.enums import FacingDirection
-    from common.schemas import Coords
     from emulator.game_state import GameState
     from overworld_map.schemas import OverworldMap
 
@@ -24,6 +24,7 @@ class CurrentMapView:
     navigation_tiles: np.ndarray
     reachable_coords: frozenset[Coords]
     visible_coords: frozenset[Coords]
+    display_origin: Coords
     display_tiles: np.ndarray
     exploration_candidates: tuple[Coords, ...]
     boundary_tiles: dict[FacingDirection, tuple[Coords, ...]]
@@ -33,7 +34,7 @@ def build_current_map_view(
     overworld_map: OverworldMap,
     game_state: GameState,
 ) -> CurrentMapView:
-    """Build the current reachable region using the navigation service's movement rules."""
+    """Build the current reachable region using the shared overworld traversal rules."""
     navigation_tiles = get_current_map_tiles(overworld_map, game_state)
     reachable = navigation.get_accessible_coords(
         game_state.player.coords,
@@ -43,13 +44,24 @@ def build_current_map_view(
     )
     reachable_coords = frozenset(reachable)
     visible_coords = _get_visible_coords(reachable_coords, navigation_tiles)
-    display_tiles = np.full(
-        navigation_tiles.shape,
+    display_top = min(coords.row for coords in visible_coords)
+    display_bottom = max(coords.row for coords in visible_coords)
+    display_left = min(coords.col for coords in visible_coords)
+    display_right = max(coords.col for coords in visible_coords)
+    region_tiles = navigation_tiles[
+        display_top : display_bottom + 1,
+        display_left : display_right + 1,
+    ]
+    display_tiles = np.where(
+        region_tiles == AsciiTile.WALL,
+        region_tiles,
         AsciiTile.OUTSIDE_REGION,
-        dtype=navigation_tiles.dtype,
     )
     for coords in visible_coords:
-        display_tiles[coords.row, coords.col] = navigation_tiles[coords.row, coords.col]
+        display_tiles[coords.row - display_top, coords.col - display_left] = navigation_tiles[
+            coords.row,
+            coords.col,
+        ]
 
     boundary_tiles = {
         direction: tuple(coords)
@@ -63,6 +75,7 @@ def build_current_map_view(
         navigation_tiles=navigation_tiles,
         reachable_coords=reachable_coords,
         visible_coords=visible_coords,
+        display_origin=Coords(row=display_top, col=display_left),
         display_tiles=display_tiles,
         exploration_candidates=tuple(
             navigation.get_exploration_candidates(reachable, navigation_tiles),

--- a/agent/overworld/map_view.py
+++ b/agent/overworld/map_view.py
@@ -1,0 +1,96 @@
+"""Derived navigation view of the player's current map region."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from agent.overworld import navigation
+from common.enums import AsciiTile
+from overworld_map.views import get_current_map_tiles
+
+if TYPE_CHECKING:
+    from common.enums import FacingDirection
+    from common.schemas import Coords
+    from emulator.game_state import GameState
+    from overworld_map.schemas import OverworldMap
+
+
+@dataclass(slots=True, frozen=True, kw_only=True)
+class CurrentMapView:
+    """Ephemeral agent-facing view of one reachable region of an explored map."""
+
+    overworld_map: OverworldMap
+    navigation_tiles: np.ndarray
+    reachable_coords: frozenset[Coords]
+    visible_coords: frozenset[Coords]
+    display_tiles: np.ndarray
+    exploration_candidates: tuple[Coords, ...]
+    boundary_tiles: dict[FacingDirection, tuple[Coords, ...]]
+
+
+def build_current_map_view(
+    overworld_map: OverworldMap,
+    game_state: GameState,
+) -> CurrentMapView:
+    """Build the current reachable region using the navigation service's movement rules."""
+    navigation_tiles = get_current_map_tiles(overworld_map, game_state)
+    reachable = navigation.get_accessible_coords(
+        game_state.player.coords,
+        navigation_tiles,
+        overworld_map.blockages,
+        game_state.get_hm_tiles(),
+    )
+    reachable_coords = frozenset(reachable)
+    visible_coords = _get_visible_coords(reachable_coords, navigation_tiles)
+    display_tiles = np.full(
+        navigation_tiles.shape,
+        AsciiTile.OUTSIDE_REGION,
+        dtype=navigation_tiles.dtype,
+    )
+    for coords in visible_coords:
+        display_tiles[coords.row, coords.col] = navigation_tiles[coords.row, coords.col]
+
+    boundary_tiles = {
+        direction: tuple(coords)
+        for direction, coords in navigation.get_map_boundary_tiles(
+            reachable,
+            overworld_map,
+        ).items()
+    }
+    return CurrentMapView(
+        overworld_map=overworld_map,
+        navigation_tiles=navigation_tiles,
+        reachable_coords=reachable_coords,
+        visible_coords=visible_coords,
+        display_tiles=display_tiles,
+        exploration_candidates=tuple(
+            navigation.get_exploration_candidates(reachable, navigation_tiles),
+        ),
+        boundary_tiles=boundary_tiles,
+    )
+
+
+def _get_visible_coords(
+    reachable_coords: frozenset[Coords],
+    navigation_tiles: np.ndarray,
+) -> frozenset[Coords]:
+    """Include the reachable region and the terrain immediately bounding it."""
+    visible = set(reachable_coords)
+    height, width = navigation_tiles.shape
+    walkable_tiles = set(AsciiTile.get_walkable_tiles())
+    spinner_tiles = set(AsciiTile.get_spinner_tiles())
+    for coords in reachable_coords:
+        for row_offset, col_offset in ((0, 1), (1, 0), (0, -1), (-1, 0)):
+            neighbor = coords + (row_offset, col_offset)  # noqa: RUF005
+            if not (0 <= neighbor.row < height and 0 <= neighbor.col < width):
+                continue
+            tile = navigation_tiles[neighbor.row, neighbor.col]
+            if tile in spinner_tiles:
+                spinner_path = navigation.get_spinner_path(neighbor, navigation_tiles)
+                if spinner_path is not None:
+                    visible.update(spinner_path)
+                continue
+            if tile == AsciiTile.UNSEEN or tile not in walkable_tiles:
+                visible.add(neighbor)
+    return frozenset(visible)

--- a/agent/overworld/navigation.py
+++ b/agent/overworld/navigation.py
@@ -1,7 +1,7 @@
-"""Pure algorithmic logic for navigation operations.
+"""Pure algorithms shared by overworld navigation and map-region views.
 
-This module contains the core algorithmic functions for navigation, separate from any formatting
-concerns to make them easier to test.
+This module contains traversal, pathfinding, exploration, and map-boundary calculations without
+depending on agent presentation or tool services.
 """
 
 from typing import TYPE_CHECKING
@@ -270,6 +270,13 @@ def _is_blocked(
 
 def get_spinner_destination(pos: Coords, tiles: np.ndarray) -> Coords | None:
     """Get a spinner's known destination, if its full path has been revealed."""
+    path = get_spinner_path(pos, tiles)
+    return path[-1] if path is not None else None
+
+
+def get_spinner_path(pos: Coords, tiles: np.ndarray) -> tuple[Coords, ...] | None:
+    """Get every coordinate traversed from a spinner to its revealed destination."""
+    path = [pos]
     tile = tiles[pos.row, pos.col]
     direction = _SPINNER_DIRECTION_MAP[tile]
 
@@ -278,8 +285,9 @@ def get_spinner_destination(pos: Coords, tiles: np.ndarray) -> Coords | None:
         new_tile = tiles[new_pos.row, new_pos.col]
         if new_tile == AsciiTile.UNSEEN:
             return None
+        path.append(new_pos)
         if new_tile == AsciiTile.SPINNER_STOP:
-            return new_pos
+            return tuple(path)
         if new_tile in AsciiTile.get_spinner_tiles():
             direction = _SPINNER_DIRECTION_MAP[new_tile]
         pos = new_pos

--- a/agent/overworld/prompts.py
+++ b/agent/overworld/prompts.py
@@ -59,17 +59,17 @@ The tile directly to the right of you is "{{tile_right}}"{{blocked_right}}.
 {{connections}}
 </map_connections>
 
-The following discovered sprites are in your current region or current screen:
+The following discovered sprites are in your current region:
 <known_sprites>
 {{known_sprites}}
 </known_sprites>
 
-The following discovered warp tiles are in your current region or current screen:
+The following discovered warp tiles are in your current region:
 <known_warps>
 {{known_warps}}
 </known_warps>
 
-The following discovered signs are in your current region or current screen:
+The following discovered signs are in your current region:
 <known_signs>
 {{known_signs}}
 </known_signs>

--- a/agent/overworld/prompts.py
+++ b/agent/overworld/prompts.py
@@ -127,6 +127,9 @@ observations.
 
 {state}
 
+Regularly reflect on what you are trying to accomplish and use the goal tools
+to keep your goals useful and current.
+
 The following accessible coordinates are adjacent to unseen territory on the
 current map. They are therefore top candidates for exploration. If the section
 below is empty, then you have already explored all of the accessible tiles on

--- a/agent/overworld/prompts.py
+++ b/agent/overworld/prompts.py
@@ -2,7 +2,12 @@
 
 from typing import TYPE_CHECKING
 
-from agent.formatting.game_state import format_party_info, format_pc_info, format_player_info
+from agent.formatting.game_state import (
+    format_inventory_info,
+    format_party_info,
+    format_pc_info,
+    format_player_info,
+)
 from agent.formatting.memory import format_goals, format_rolling_memory
 from agent.overworld import formatting
 from common.constants import PLAYER_OFFSET_X, PLAYER_OFFSET_Y, SCREEN_HEIGHT, SCREEN_WIDTH
@@ -137,11 +142,6 @@ current region. Boundaries in other regions of the same larger map are omitted.
 {map_boundaries}
 </map_boundaries>
 
-Your current inventory is listed below:
-<inventory_indices>
-{inventory_indices}
-</inventory_indices>
-
 Use navigation for ordinary movement within the current map. Use press_buttons
 for direct interactions, changing direction, or sending the final directional
 input needed to cross a map boundary or warp. Prefer a specialized tool
@@ -226,16 +226,13 @@ def build_overworld_decision_prompt(
         )
         biking_warning = ""
 
-    inventory_indices = "\n".join(
-        f"[{index}] {item.name} (x{item.quantity})"
-        for index, item in enumerate(game_state.inventory.items)
-    )
     sections = (
         format_rolling_memory(context.state.rolling_memory),
         format_goals(context.state.goals),
         _format_overworld_map(map_view, game_state),
         format_player_info(game_state),
         format_party_info(game_state),
+        format_inventory_info(game_state),
         format_pc_info(game_state),
     )
     return OVERWORLD_DECISION_PROMPT.format(
@@ -243,5 +240,4 @@ def build_overworld_decision_prompt(
         exploration_candidates=exploration_candidates,
         map_boundaries=map_boundaries,
         biking_warning=biking_warning,
-        inventory_indices=inventory_indices,
     )

--- a/agent/overworld/prompts.py
+++ b/agent/overworld/prompts.py
@@ -5,15 +5,13 @@ from typing import TYPE_CHECKING
 from agent.formatting.game_state import format_party_info, format_pc_info, format_player_info
 from agent.formatting.memory import format_goals, format_rolling_memory
 from agent.overworld import formatting
-from agent.overworld.tools.navigate import utils
 from common.constants import PLAYER_OFFSET_X, PLAYER_OFFSET_Y, SCREEN_HEIGHT, SCREEN_WIDTH
 from common.enums import AsciiTile, BlockedDirection
-from overworld_map.views import get_current_map_tiles
 
 if TYPE_CHECKING:
     from agent.context import AgentContext
+    from agent.overworld.map_view import CurrentMapView
     from emulator.game_state import GameState
-    from overworld_map.schemas import OverworldMap
 
 OVERWORLD_MAP_PROMPT = f"""
 <map_info>
@@ -21,15 +19,16 @@ Map name: {{map_name}}
 <ascii_screen>
 {{ascii_screen}}
 </ascii_screen>
-<whole_map>
+<current_map_region>
 {{ascii_map}}
-</whole_map>
-You have explored {{explored_percentage}} of this map.
+</current_map_region>
 <legend>
 {{legend}}
 </legend>
 
 The map coordinates in row-column order start at (0, 0) in the top left corner. The rows increase from top to bottom, and the columns increase from left to right. The full size of the current map in row-column order is {{height}}x{{width}} blocks.
+
+The current map region above uses the permanent coordinates of the complete map. It shows only the region that is currently navigable from your position and the terrain immediately bordering that region. "{AsciiTile.OUTSIDE_REGION}" masks every other coordinate, which may be unexplored or may belong to another disconnected region of this larger map. Previously remembered coordinates remain valid, but coordinates masked with "{AsciiTile.OUTSIDE_REGION}" cannot be reached from your current region. Coordinates never change when regions expand, merge, or are entered from another location.
 
 <screen_position>
 The ASCII screen is always ({SCREEN_HEIGHT}x{SCREEN_WIDTH}) blocks in size, and is always centered such that you are in position ({PLAYER_OFFSET_Y}, {PLAYER_OFFSET_X}) in screen coordinates (not map coordinates). It corresponds 1:1 with the screenshot provided to you above. Note that the screen can extend outside the boundaries of the map (i.e. when the screen boundary rows or columns are negative or exceed the map size). This should help you navigate from one map to another.
@@ -55,17 +54,17 @@ The tile directly to the right of you is "{{tile_right}}"{{blocked_right}}.
 {{connections}}
 </map_connections>
 
-You have discovered the following sprites on the portion of the map that you have revealed so far. Do not make any assumptions about who or what a sprite is before you have interacted with it.
+The following discovered sprites are in your current region or current screen:
 <known_sprites>
 {{known_sprites}}
 </known_sprites>
 
-You have discovered the following warp tiles on the portion of the map that you have revealed so far:
+The following discovered warp tiles are in your current region or current screen:
 <known_warps>
 {{known_warps}}
 </known_warps>
 
-You have discovered the following signs on the portion of the map that you have revealed so far:
+The following discovered signs are in your current region or current screen:
 <known_signs>
 {{known_signs}}
 </known_signs>
@@ -84,11 +83,12 @@ Navigation tips:
 - Pay attention to the "sprite is labeled" section in each sprite. This will tell you what the sprite is labeled as in the game's memory, and should help you determine what the sprite is.
 - Focus on the map when you are trying to navigate within a map. Focus on the screen when you are trying to navigate between maps.
 
-The current ASCII screen is derived from current game memory, while the whole map combines those observations over time. Prefer the ASCII information for tile and coordinate reasoning, and use the screenshot as supplemental visual context.
+The current ASCII screen is derived from current game memory, while the current map region combines those observations over time. Prefer the ASCII information for tile and coordinate reasoning, and use the screenshot as supplemental visual context.
 </map_info>
 """.strip()
 
 LEGEND_MAP = {
+    AsciiTile.OUTSIDE_REGION: "A coordinate outside your current navigable region. It may be unexplored or reachable only from somewhere else, so do not target it directly.",
     AsciiTile.UNSEEN: "Tiles that you have not yet explored. Move toward these tiles to reveal them.",
     AsciiTile.WALL: "A barrier (usually a wall or an object) that you cannot pass through.",
     AsciiTile.WATER: "Water.",
@@ -131,11 +131,8 @@ most efficient way to explore the map.
 {exploration_candidates}
 </exploration_candidates>
 
-If there are maps connected to the current map, the following section will
-guide you on how to navigate to the boundaries of the current map so that you
-can transition to the next map in the next iteration if you choose to do so.
-If this section is empty, it means that the current map is not connected to
-any other maps and has to be exited via warp tiles.
+The following section lists only connected-map boundaries reachable from your
+current region. Boundaries in other regions of the same larger map are omitted.
 <map_boundaries>
 {map_boundaries}
 </map_boundaries>
@@ -159,25 +156,24 @@ will be returned after each tool executes.
 """.strip()
 
 
-def _format_overworld_map(current_map: OverworldMap, game_state: GameState) -> str:
+def _format_overworld_map(map_view: CurrentMapView, game_state: GameState) -> str:
     """Build the explored-map portion of the overworld prompt."""
+    current_map = map_view.overworld_map
     screen = game_state.get_ascii_screen()
     facing_tile, facing_tile_coords = formatting.get_facing_tile_notes(game_state)
     tile_above, blocked_above = formatting.get_tile_notes(BlockedDirection.UP, screen)
     tile_below, blocked_below = formatting.get_tile_notes(BlockedDirection.DOWN, screen)
     tile_left, blocked_left = formatting.get_tile_notes(BlockedDirection.LEFT, screen)
     tile_right, blocked_right = formatting.get_tile_notes(BlockedDirection.RIGHT, screen)
-    current_tiles = get_current_map_tiles(current_map, game_state)
     return OVERWORLD_MAP_PROMPT.format(
         map_name=current_map.id.name,
-        ascii_map="\n".join("".join(row) for row in current_tiles),
-        legend=formatting.format_legend(current_map, LEGEND_MAP),
+        ascii_map="\n".join("".join(row) for row in map_view.display_tiles),
+        legend=formatting.format_legend(map_view, LEGEND_MAP),
         height=current_map.height,
         width=current_map.width,
-        known_sprites=formatting.format_sprite_notes(current_map, game_state),
-        known_warps=formatting.format_warp_notes(current_map, game_state),
-        known_signs=formatting.format_sign_notes(current_map, game_state),
-        explored_percentage=formatting.format_explored_percentage(current_map),
+        known_sprites=formatting.format_sprite_notes(map_view, game_state),
+        known_warps=formatting.format_warp_notes(map_view, game_state),
+        known_signs=formatting.format_sign_notes(map_view, game_state),
         ascii_screen=screen,
         player_coords=game_state.player.coords,
         player_terrain=current_map.terrain[game_state.player.coords.row][
@@ -198,16 +194,17 @@ def _format_overworld_map(current_map: OverworldMap, game_state: GameState) -> s
         screen_left=game_state.screen.left,
         screen_bottom=game_state.screen.bottom,
         screen_right=game_state.screen.right,
-        connections=formatting.format_connection_notes(current_map),
+        connections=formatting.format_connection_notes(map_view),
     )
 
 
 def build_overworld_decision_prompt(
     context: AgentContext,
-    current_map: OverworldMap,
+    map_view: CurrentMapView,
     game_state: GameState,
 ) -> str:
     """Build the initial prompt for one overworld-agent run."""
+    current_map = map_view.overworld_map
     if game_state.player.is_biking:
         unavailable = "Navigation data is unavailable while riding a bike."
         exploration_candidates = unavailable
@@ -219,20 +216,14 @@ def build_overworld_decision_prompt(
             "button tool to move around the map."
         )
     else:
-        navigation_tiles = get_current_map_tiles(current_map, game_state)
-        accessible = utils.get_accessible_coords(
-            game_state.player.coords,
-            navigation_tiles,
-            current_map.blockages,
-            game_state.get_hm_tiles(),
-        )
-        exploration = utils.get_exploration_candidates(accessible, navigation_tiles)
-        boundaries = utils.get_map_boundary_tiles(accessible, current_map)
         exploration_candidates = formatting.format_exploration_candidates(
-            exploration,
+            map_view.exploration_candidates,
             current_map,
         )
-        map_boundaries = formatting.format_map_boundary_tiles(boundaries, current_map)
+        map_boundaries = formatting.format_map_boundary_tiles(
+            map_view.boundary_tiles,
+            current_map,
+        )
         biking_warning = ""
 
     inventory_indices = "\n".join(
@@ -242,7 +233,7 @@ def build_overworld_decision_prompt(
     sections = (
         format_rolling_memory(context.state.rolling_memory),
         format_goals(context.state.goals),
-        _format_overworld_map(current_map, game_state),
+        _format_overworld_map(map_view, game_state),
         format_player_info(game_state),
         format_party_info(game_state),
         format_pc_info(game_state),

--- a/agent/overworld/prompts.py
+++ b/agent/overworld/prompts.py
@@ -19,16 +19,16 @@ Map name: {{map_name}}
 <ascii_screen>
 {{ascii_screen}}
 </ascii_screen>
-<current_map_region>
+<current_map_region top_row="{{region_top}}" left_column="{{region_left}}">
 {{ascii_map}}
 </current_map_region>
 <legend>
 {{legend}}
 </legend>
 
-The map coordinates in row-column order start at (0, 0) in the top left corner. The rows increase from top to bottom, and the columns increase from left to right. The full size of the current map in row-column order is {{height}}x{{width}} blocks.
+The complete map's global coordinates in row-column order start at (0, 0) in its top left corner. Rows increase from top to bottom, and columns increase from left to right.
 
-The current map region above uses the permanent coordinates of the complete map. It shows only the region that is currently navigable from your position and the terrain immediately bordering that region. "{AsciiTile.OUTSIDE_REGION}" masks every other coordinate, which may be unexplored or may belong to another disconnected region of this larger map. Previously remembered coordinates remain valid, but coordinates masked with "{AsciiTile.OUTSIDE_REGION}" cannot be reached from your current region. Coordinates never change when regions expand, merge, or are entered from another location.
+The current map region is a rectangular crop enclosing the area currently navigable from your position and its bordering terrain. Its first displayed tile is global coordinate ({{region_top}}, {{region_left}}), as recorded in the tag above; displayed rows and columns continue from there without renumbering the underlying coordinates. Walls are shown throughout the rectangle so its physical shape remains clear. "{AsciiTile.OUTSIDE_REGION}" marks every other coordinate inside the rectangle that is outside your current navigable region. Do not target those coordinates directly. Previously remembered coordinates remain valid, and coordinates never change when regions expand, merge, or are entered from another location.
 
 <screen_position>
 The ASCII screen is always ({SCREEN_HEIGHT}x{SCREEN_WIDTH}) blocks in size, and is always centered such that you are in position ({PLAYER_OFFSET_Y}, {PLAYER_OFFSET_X}) in screen coordinates (not map coordinates). It corresponds 1:1 with the screenshot provided to you above. Note that the screen can extend outside the boundaries of the map (i.e. when the screen boundary rows or columns are negative or exceed the map size). This should help you navigate from one map to another.
@@ -88,7 +88,7 @@ The current ASCII screen is derived from current game memory, while the current 
 """.strip()
 
 LEGEND_MAP = {
-    AsciiTile.OUTSIDE_REGION: "A coordinate outside your current navigable region. It may be unexplored or reachable only from somewhere else, so do not target it directly.",
+    AsciiTile.OUTSIDE_REGION: "A non-wall coordinate outside your current navigable region. It may be unexplored or reachable only from somewhere else, so do not target it directly.",
     AsciiTile.UNSEEN: "Tiles that you have not yet explored. Move toward these tiles to reveal them.",
     AsciiTile.WALL: "A barrier (usually a wall or an object) that you cannot pass through.",
     AsciiTile.WATER: "Water.",
@@ -169,8 +169,8 @@ def _format_overworld_map(map_view: CurrentMapView, game_state: GameState) -> st
         map_name=current_map.id.name,
         ascii_map="\n".join("".join(row) for row in map_view.display_tiles),
         legend=formatting.format_legend(map_view, LEGEND_MAP),
-        height=current_map.height,
-        width=current_map.width,
+        region_top=map_view.display_origin.row,
+        region_left=map_view.display_origin.col,
         known_sprites=formatting.format_sprite_notes(map_view, game_state),
         known_warps=formatting.format_warp_notes(map_view, game_state),
         known_signs=formatting.format_sign_notes(map_view, game_state),

--- a/agent/overworld/prompts.py
+++ b/agent/overworld/prompts.py
@@ -70,7 +70,7 @@ The following discovered signs are in your current region or current screen:
 </known_signs>
 
 Navigation tips:
-- You should explore as much of the map as possible to reveal unexplored tiles, as they may be hiding important sprites or warp tiles. Tiles are considered explored once they are on screen, so move towards unseen territory when you are stuck or unsure how to proceed.
+- You should explore as much of the map as possible, as it may be hiding important sprites or warp tiles. Exploration is not only a matter of revealing tiles; interact with what you discover along the way. Tiles are considered explored once they are on screen, so move towards unseen territory when you are stuck or unsure how to proceed.
 - The orientation of the map and screen is always fixed, regardless of the direction that you are facing.
 - Do not use the action button on a warp.
 - To connect from one map to another, you must either use a warp tile, or, *in outdoor maps only*, walk off the edge of the map. In outdoor maps, you will never be able to walk through a wall or barrier for any reason. You have to find where the edge of the map connects to the next map by looking at the ASCII screen.

--- a/agent/overworld/tests/unit/test_map_view.py
+++ b/agent/overworld/tests/unit/test_map_view.py
@@ -1,0 +1,71 @@
+"""Tests for the derived current-map view."""
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, cast
+
+import pytest
+
+from agent.overworld.map_view import build_current_map_view
+from common.enums import AsciiTile, MapId
+from common.schemas import Coords
+from overworld_map.schemas import OverworldMap
+
+if TYPE_CHECKING:
+    from emulator.game_state import GameState
+
+
+@pytest.mark.unit
+def test_current_map_view_masks_disconnected_terrain_without_mutating_map() -> None:
+    """Only the player's navigable region and its immediate boundary are exposed."""
+    overworld_map = OverworldMap(
+        id=MapId.ROUTE_2,
+        terrain=[list("∙∙▓∙∙"), list("∙∙▓∙∙")],
+        blockages={},
+        known_sprite_ids=set(),
+        known_sign_ids=set(),
+        known_warp_ids=set(),
+        known_map_ids=frozenset(),
+        north_connection=None,
+        south_connection=None,
+        east_connection=None,
+        west_connection=None,
+    )
+    game_state = cast(
+        "GameState",
+        SimpleNamespace(
+            sprites={},
+            warps={},
+            signs={},
+            pikachu=SimpleNamespace(is_rendered=False),
+            player=SimpleNamespace(coords=Coords(row=0, col=0)),
+            get_hm_tiles=list,
+        ),
+    )
+
+    map_view = build_current_map_view(overworld_map, game_state)
+
+    assert map_view.display_tiles.tolist() == [
+        [
+            AsciiTile.PLAYER,
+            AsciiTile.FREE,
+            AsciiTile.WALL,
+            AsciiTile.OUTSIDE_REGION,
+            AsciiTile.OUTSIDE_REGION,
+        ],
+        [
+            AsciiTile.FREE,
+            AsciiTile.FREE,
+            AsciiTile.WALL,
+            AsciiTile.OUTSIDE_REGION,
+            AsciiTile.OUTSIDE_REGION,
+        ],
+    ]
+    assert map_view.reachable_coords == frozenset(
+        {
+            Coords(row=0, col=0),
+            Coords(row=0, col=1),
+            Coords(row=1, col=0),
+            Coords(row=1, col=1),
+        },
+    )
+    assert overworld_map.terrain == [list("∙∙▓∙∙"), list("∙∙▓∙∙")]

--- a/agent/overworld/tests/unit/test_map_view.py
+++ b/agent/overworld/tests/unit/test_map_view.py
@@ -15,11 +15,17 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.unit
-def test_current_map_view_masks_disconnected_terrain_without_mutating_map() -> None:
-    """Only the player's navigable region and its immediate boundary are exposed."""
+def test_current_map_view_crops_region_without_mutating_map() -> None:
+    """The display is a rectangular global-coordinate crop around the current region."""
     overworld_map = OverworldMap(
         id=MapId.ROUTE_2,
-        terrain=[list("∙∙▓∙∙"), list("∙∙▓∙∙")],
+        terrain=[
+            list("▓▓▓▓▓▓▓"),
+            list("▓∙▓▓▓▓▓"),
+            list("▓▓∙∙▓∙▓"),
+            list("▓▓∙∙▓∙▓"),
+            list("▓▓▓▓∙▓▓"),
+        ],
         blockages={},
         known_sprite_ids=set(),
         known_sign_ids=set(),
@@ -37,7 +43,7 @@ def test_current_map_view_masks_disconnected_terrain_without_mutating_map() -> N
             warps={},
             signs={},
             pikachu=SimpleNamespace(is_rendered=False),
-            player=SimpleNamespace(coords=Coords(row=0, col=0)),
+            player=SimpleNamespace(coords=Coords(row=2, col=2)),
             get_hm_tiles=list,
         ),
     )
@@ -46,26 +52,43 @@ def test_current_map_view_masks_disconnected_terrain_without_mutating_map() -> N
 
     assert map_view.display_tiles.tolist() == [
         [
+            AsciiTile.OUTSIDE_REGION,
+            AsciiTile.WALL,
+            AsciiTile.WALL,
+            AsciiTile.WALL,
+        ],
+        [
+            AsciiTile.WALL,
             AsciiTile.PLAYER,
             AsciiTile.FREE,
             AsciiTile.WALL,
-            AsciiTile.OUTSIDE_REGION,
-            AsciiTile.OUTSIDE_REGION,
         ],
         [
+            AsciiTile.WALL,
             AsciiTile.FREE,
             AsciiTile.FREE,
             AsciiTile.WALL,
-            AsciiTile.OUTSIDE_REGION,
+        ],
+        [
+            AsciiTile.WALL,
+            AsciiTile.WALL,
+            AsciiTile.WALL,
             AsciiTile.OUTSIDE_REGION,
         ],
     ]
+    assert map_view.display_origin == Coords(row=1, col=1)
     assert map_view.reachable_coords == frozenset(
         {
-            Coords(row=0, col=0),
-            Coords(row=0, col=1),
-            Coords(row=1, col=0),
-            Coords(row=1, col=1),
+            Coords(row=2, col=2),
+            Coords(row=2, col=3),
+            Coords(row=3, col=2),
+            Coords(row=3, col=3),
         },
     )
-    assert overworld_map.terrain == [list("∙∙▓∙∙"), list("∙∙▓∙∙")]
+    assert overworld_map.terrain == [
+        list("▓▓▓▓▓▓▓"),
+        list("▓∙▓▓▓▓▓"),
+        list("▓▓∙∙▓∙▓"),
+        list("▓▓∙∙▓∙▓"),
+        list("▓▓▓▓∙▓▓"),
+    ]

--- a/agent/overworld/tools/create_goal/interface.py
+++ b/agent/overworld/tools/create_goal/interface.py
@@ -7,8 +7,7 @@ from pydantic_ai import Tool
 
 from agent.formatting.memory import format_goals
 from agent.overworld.tools.create_goal.service import (
-    PrimaryGoalAlreadyExistsError,
-    SecondaryGoalLimitReachedError,
+    GoalLimitReachedError,
 )
 from agent.overworld.tools.create_goal.service import (
     create_goal as create_goal_service,
@@ -27,23 +26,11 @@ def build_create_goal_tool(context: AgentContext) -> Tool[AgentContext]:
 
     async def create_goal(
         goal: Annotated[str, Field(min_length=1)],
-        *,
-        is_primary: bool,
     ) -> OverworldToolResult:
-        """Create one new goal worth pursuing.
+        """Create one goal worth keeping in mind.
 
-        Set ``is_primary`` to true only for your one primary goal. The primary
-        goal represents one major outcome already established by your current
-        context. It is not a plan or a list of every step required to reach that
-        outcome. You should normally maintain one primary goal and keep it
-        stable while its intended outcome remains relevant. You cannot create a
-        new primary goal while one exists; either update the current goal's
-        text, or delete it and create its replacement in a subsequent tool call.
-
-        Set ``is_primary`` to false for secondary goals. Each secondary goal
-        represents one discrete prerequisite or useful step that directly
-        supports the primary goal. You can have up to three secondary goals at
-        once. There is no minimum requirement.
+        The goal list has a fixed capacity. If the list is full, update or
+        delete an existing goal before creating another.
 
         Create goals only from objectives justified by current structured
         information, observed game text, or recorded memory. Do not invent
@@ -52,42 +39,38 @@ def build_create_goal_tool(context: AgentContext) -> Tool[AgentContext]:
         has not introduced a location, character, item, or objective, it must
         not appear in a goal.
 
-        Every goal should contain one outcome. Strongly avoid the word "and" in
-        goal text because it usually joins multiple goals that should be split.
-        This is guidance, not an absolute prohibition when "and" is genuinely
-        part of a single indivisible outcome. A good goal must be specific,
-        measurable, achievable, and relevant to your current progress. Goals
-        should also be incremental. Do not make "defeat the elite four" your
-        goal when you have just started the game.
+        Strongly avoid the word "and" in goal text because it usually joins
+        multiple goals that should be split. This is guidance, not an absolute
+        prohibition when "and" is genuinely part of one indivisible outcome.
+        A good goal is specific, achievable, and relevant to your current
+        progress.
 
         New goals must be distinct from existing goals. Do not create a goal
         that is essentially the same as another goal.
 
-        Create a goal only when recent events warrant it and the goal is not
-        already in your list. You should normally have a primary goal, but do
-        not create secondary goals merely to fill the available slots. Write
-        every goal in the first person, just like your reasoning and memories.
+        Regularly reflect on your current objectives and concerns. When several
+        priorities are active, create a separate goal for each of them. Keep
+        the list useful and current, but do not create goals merely to fill
+        every available slot. Write every goal in the first person, just like
+        your reasoning and memories.
 
         Args:
-            goal: Complete text of the specific new goal, without an index.
-            is_primary: Whether this is the primary goal rather than a
-                secondary goal.
+            goal: Complete text of the new goal, without an index.
 
         Returns:
             Fresh screenshot and the complete revised goal list.
         """
         try:
-            goals = create_goal_service(
+            updated_goals = create_goal_service(
                 goals=context.state.goals,
                 goal=goal,
-                is_primary=is_primary,
                 iteration=context.state.iteration,
             )
-        except (SecondaryGoalLimitReachedError, PrimaryGoalAlreadyExistsError) as error:
+        except GoalLimitReachedError as error:
             result = str(error)
         else:
-            context.state.goals = goals
-            result = f"Created goal.\n\n{format_goals(goals)}"
+            context.state.goals = updated_goals
+            result = f"Created goal.\n\n{format_goals(updated_goals)}"
         return await complete_overworld_action(context, result)
 
     return Tool(create_goal, require_parameter_descriptions=True)

--- a/agent/overworld/tools/create_goal/interface.py
+++ b/agent/overworld/tools/create_goal/interface.py
@@ -33,66 +33,35 @@ def build_create_goal_tool(context: AgentContext) -> Tool[AgentContext]:
         """Create one new goal worth pursuing.
 
         Set ``is_primary`` to true only for your one primary goal. The primary
-        goal represents one major outcome such as earning a badge or completing
-        another key objective required to progress through the game. It is not
-        a plan or a list of every step required to reach that outcome. You
-        should normally maintain one primary goal and keep it stable while its
-        intended outcome remains relevant. You cannot create a new primary goal
-        while one exists; either update the current goal's text, or delete it
-        and create its replacement in a subsequent tool call.
+        goal represents one major outcome already established by your current
+        context. It is not a plan or a list of every step required to reach that
+        outcome. You should normally maintain one primary goal and keep it
+        stable while its intended outcome remains relevant. You cannot create a
+        new primary goal while one exists; either update the current goal's
+        text, or delete it and create its replacement in a subsequent tool call.
 
         Set ``is_primary`` to false for secondary goals. Each secondary goal
         represents one discrete prerequisite or useful step that directly
-        supports the primary goal, such as catching a new Pokemon, finding a
-        required item, preparing for a major battle, or reaching the objective's
-        location. You can have up to three secondary goals at once. There is no
-        minimum requirement.
+        supports the primary goal. You can have up to three secondary goals at
+        once. There is no minimum requirement.
+
+        Create goals only from objectives justified by current structured
+        information, observed game text, or recorded memory. Do not invent
+        goals from general Pokemon knowledge, examples in these instructions,
+        or assumptions about future game progression. If your current context
+        has not introduced a location, character, item, or objective, it must
+        not appear in a goal.
 
         Every goal should contain one outcome. Strongly avoid the word "and" in
         goal text because it usually joins multiple goals that should be split.
         This is guidance, not an absolute prohibition when "and" is genuinely
-        part of a single indivisible outcome.
-
-        - Bad primary goal: "I will heal my team, catch another Pokemon, reach
-          Pewter City, and earn the BOULDERBADGE."
-        - Good primary goal: "I will earn the BOULDERBADGE from Brock."
-        - Good secondary goal: "I will heal my team at the Pewter City Pokemon
-          Center."
-        - Good secondary goal: "I will catch a Pokemon that has a super
-          effective attack against Brock's team."
-
-        A good goal must be SMART:
-
-        - Specific: The goal must be clearly defined and not vague.
-          - Bad: "Level up my Pokemon"
-          - Good: "Level up my [pokemon] to level [level]"
-        - Measurable: The goal must have clear criteria for success.
-          - Bad: "Complete Pewter City"
-          - Good: "Earn the BOULDERBADGE from Brock"
-        - Achievable: The goal must be possible within the confines of the
-          game.
-          - Bad: "Get my whole team to level 100" (not possible before
-            becoming the Champion due to the level cap)
-          - Good: "Catch a [pokemon] in [location]" (assuming that you have
-            seen that Pokemon at that location)
-        - Relevant: The goal must be relevant to your ultimate goal of
-          collecting all eight badges and becoming the Champion. Completing
-          the Pokedex is not relevant to this goal, except insofar as you need
-          to catch Pokemon to build your team.
-          - Bad: "Catch five Magikarp" (silly and pointless)
-          - Good: "Catch a [pokemon] in [location] to help me defeat [major
-            opponent]"
-        - Time-bound: The least-relevant of the SMART criteria for your
-          purposes, but try to ensure that your goals have clear temporal
-          boundaries when relevant.
-          - Suboptimal: "Train my Pokemon"
-          - Good: "Train my [pokemon] to level [level] before challenging
-            [major opponent]"
+        part of a single indivisible outcome. A good goal must be specific,
+        measurable, achievable, and relevant to your current progress. Goals
+        should also be incremental. Do not make "defeat the elite four" your
+        goal when you have just started the game.
 
         New goals must be distinct from existing goals. Do not create a goal
-        that is essentially the same as another goal. Base new goals on your
-        experience in the game as recorded in memory or player information,
-        not on prior Pokemon knowledge, which is prone to error.
+        that is essentially the same as another goal.
 
         Create a goal only when recent events warrant it and the goal is not
         already in your list. You should normally have a primary goal, but do

--- a/agent/overworld/tools/create_goal/interface.py
+++ b/agent/overworld/tools/create_goal/interface.py
@@ -7,8 +7,8 @@ from pydantic_ai import Tool
 
 from agent.formatting.memory import format_goals
 from agent.overworld.tools.create_goal.service import (
-    OtherGoalLimitReachedError,
     PrimaryGoalAlreadyExistsError,
+    SecondaryGoalLimitReachedError,
 )
 from agent.overworld.tools.create_goal.service import (
     create_goal as create_goal_service,
@@ -33,19 +33,33 @@ def build_create_goal_tool(context: AgentContext) -> Tool[AgentContext]:
         """Create one new goal worth pursuing.
 
         Set ``is_primary`` to true only for your one primary goal. The primary
-        goal represents a major milestone such as a gym battle or another key
-        objective required to progress through the game. You should normally
-        maintain one primary goal and change it sparingly. You cannot create a
-        new primary goal while one exists; either update the current goal's
-        text, or delete it and create its replacement in a subsequent tool
-        call.
+        goal represents one major outcome such as earning a badge or completing
+        another key objective required to progress through the game. It is not
+        a plan or a list of every step required to reach that outcome. You
+        should normally maintain one primary goal and keep it stable while its
+        intended outcome remains relevant. You cannot create a new primary goal
+        while one exists; either update the current goal's text, or delete it
+        and create its replacement in a subsequent tool call.
 
-        Set ``is_primary`` to false for other goals. Other goals may directly
-        support the primary goal, such as finding a required item or navigating
-        to the primary objective, or may be independently useful, such as
-        catching or training Pokemon, healing, buying items, or exploring an
-        area. You can have up to five other goals at once. There is no minimum
-        requirement.
+        Set ``is_primary`` to false for secondary goals. Each secondary goal
+        represents one discrete prerequisite or useful step that directly
+        supports the primary goal, such as catching a new Pokemon, finding a
+        required item, preparing for a major battle, or reaching the objective's
+        location. You can have up to three secondary goals at once. There is no
+        minimum requirement.
+
+        Every goal should contain one outcome. Strongly avoid the word "and" in
+        goal text because it usually joins multiple goals that should be split.
+        This is guidance, not an absolute prohibition when "and" is genuinely
+        part of a single indivisible outcome.
+
+        - Bad primary goal: "I will heal my team, catch another Pokemon, reach
+          Pewter City, and earn the BOULDERBADGE."
+        - Good primary goal: "I will earn the BOULDERBADGE from Brock."
+        - Good secondary goal: "I will heal my team at the Pewter City Pokemon
+          Center."
+        - Good secondary goal: "I will catch a Pokemon that has a super
+          effective attack against Brock's team."
 
         A good goal must be SMART:
 
@@ -54,8 +68,7 @@ def build_create_goal_tool(context: AgentContext) -> Tool[AgentContext]:
           - Good: "Level up my [pokemon] to level [level]"
         - Measurable: The goal must have clear criteria for success.
           - Bad: "Complete Pewter City"
-          - Good: "Defeat Brock in the Pewter City Gym and collect the
-            BOULDERBADGE"
+          - Good: "Earn the BOULDERBADGE from Brock"
         - Achievable: The goal must be possible within the confines of the
           game.
           - Bad: "Get my whole team to level 100" (not possible before
@@ -67,14 +80,14 @@ def build_create_goal_tool(context: AgentContext) -> Tool[AgentContext]:
           the Pokedex is not relevant to this goal, except insofar as you need
           to catch Pokemon to build your team.
           - Bad: "Catch five Magikarp" (silly and pointless)
-          - Good: "Catch a [pokemon] in [location] and add it to my team to
-            help me defeat [major opponent]"
+          - Good: "Catch a [pokemon] in [location] to help me defeat [major
+            opponent]"
         - Time-bound: The least-relevant of the SMART criteria for your
           purposes, but try to ensure that your goals have clear temporal
           boundaries when relevant.
-          - Suboptimal: "Heal my Pokemon at the [location] Pokemon Center"
-          - Good: "Heal my Pokemon at the [location] Pokemon Center before
-            heading to [next location]"
+          - Suboptimal: "Train my Pokemon"
+          - Good: "Train my [pokemon] to level [level] before challenging
+            [major opponent]"
 
         New goals must be distinct from existing goals. Do not create a goal
         that is essentially the same as another goal. Base new goals on your
@@ -83,13 +96,13 @@ def build_create_goal_tool(context: AgentContext) -> Tool[AgentContext]:
 
         Create a goal only when recent events warrant it and the goal is not
         already in your list. You should normally have a primary goal, but do
-        not create other goals merely to fill the available slots. Write every
-        goal in the first person, just like your reasoning and memories.
+        not create secondary goals merely to fill the available slots. Write
+        every goal in the first person, just like your reasoning and memories.
 
         Args:
             goal: Complete text of the specific new goal, without an index.
-            is_primary: Whether this is the one primary goal rather than an
-                other goal.
+            is_primary: Whether this is the primary goal rather than a
+                secondary goal.
 
         Returns:
             Fresh screenshot and the complete revised goal list.
@@ -99,8 +112,9 @@ def build_create_goal_tool(context: AgentContext) -> Tool[AgentContext]:
                 goals=context.state.goals,
                 goal=goal,
                 is_primary=is_primary,
+                iteration=context.state.iteration,
             )
-        except (OtherGoalLimitReachedError, PrimaryGoalAlreadyExistsError) as error:
+        except (SecondaryGoalLimitReachedError, PrimaryGoalAlreadyExistsError) as error:
             result = str(error)
         else:
             context.state.goals = goals

--- a/agent/overworld/tools/create_goal/service.py
+++ b/agent/overworld/tools/create_goal/service.py
@@ -4,11 +4,11 @@ from copy import deepcopy
 
 from memory.goals import Goal, Goals
 
-_MAX_OTHER_GOALS = 5
+_MAX_SECONDARY_GOALS = 3
 
 
-class OtherGoalLimitReachedError(ValueError):
-    """Raised when creation would add more than five other goals."""
+class SecondaryGoalLimitReachedError(ValueError):
+    """Raised when creation would add more than three secondary goals."""
 
 
 class PrimaryGoalAlreadyExistsError(ValueError):
@@ -20,6 +20,7 @@ def create_goal(
     goals: Goals,
     goal: str,
     is_primary: bool,
+    iteration: int,
 ) -> Goals:
     """Append one new goal through the existing goal behavior.
 
@@ -27,12 +28,13 @@ def create_goal(
         goals: Current live goal collection.
         goal: Text of the new goal.
         is_primary: Whether the new goal is the primary goal.
+        iteration: Current application iteration.
 
     Returns:
         A revised goal collection containing the new goal.
 
     Raises:
-        OtherGoalLimitReachedError: If five other goals already exist.
+        SecondaryGoalLimitReachedError: If three secondary goals already exist.
         PrimaryGoalAlreadyExistsError: If you try to create a second primary goal.
     """
     if is_primary and any(existing_goal.is_primary for existing_goal in goals.goals):
@@ -41,12 +43,19 @@ def create_goal(
         )
     if (
         not is_primary
-        and sum(not existing_goal.is_primary for existing_goal in goals.goals) >= _MAX_OTHER_GOALS
+        and sum(not existing_goal.is_primary for existing_goal in goals.goals)
+        >= _MAX_SECONDARY_GOALS
     ):
-        raise OtherGoalLimitReachedError(
-            "Five other goals already exist. Update or delete one before creating another.",
+        raise SecondaryGoalLimitReachedError(
+            "Three secondary goals already exist. Update or delete one before creating another.",
         )
 
     updated_goals = deepcopy(goals)
-    updated_goals.append(Goal(goal=goal, is_primary=is_primary))
+    updated_goals.append(
+        Goal(
+            goal=goal,
+            is_primary=is_primary,
+            updated_at_iteration=iteration,
+        ),
+    )
     return updated_goals

--- a/agent/overworld/tools/create_goal/service.py
+++ b/agent/overworld/tools/create_goal/service.py
@@ -2,60 +2,39 @@
 
 from copy import deepcopy
 
-from memory.goals import Goal, Goals
-
-_MAX_SECONDARY_GOALS = 3
+from memory.goals import MAX_GOALS, Goal, Goals
 
 
-class SecondaryGoalLimitReachedError(ValueError):
-    """Raised when creation would add more than three secondary goals."""
-
-
-class PrimaryGoalAlreadyExistsError(ValueError):
-    """Raised when creation would add a second primary goal."""
+class GoalLimitReachedError(ValueError):
+    """Raised when creation would exceed the goal limit."""
 
 
 def create_goal(
     *,
     goals: Goals,
     goal: str,
-    is_primary: bool,
     iteration: int,
 ) -> Goals:
-    """Append one new goal through the existing goal behavior.
+    """Append one goal through the existing goal behavior.
 
     Args:
         goals: Current live goal collection.
         goal: Text of the new goal.
-        is_primary: Whether the new goal is the primary goal.
         iteration: Current application iteration.
 
     Returns:
         A revised goal collection containing the new goal.
 
     Raises:
-        SecondaryGoalLimitReachedError: If three secondary goals already exist.
-        PrimaryGoalAlreadyExistsError: If you try to create a second primary goal.
+        GoalLimitReachedError: If the goal limit has been reached.
     """
-    if is_primary and any(existing_goal.is_primary for existing_goal in goals.goals):
-        raise PrimaryGoalAlreadyExistsError(
-            "A primary goal already exists. Update it instead, or delete it and create another.",
-        )
-    if (
-        not is_primary
-        and sum(not existing_goal.is_primary for existing_goal in goals.goals)
-        >= _MAX_SECONDARY_GOALS
-    ):
-        raise SecondaryGoalLimitReachedError(
-            "Three secondary goals already exist. Update or delete one before creating another.",
+    if len(goals.goals) >= MAX_GOALS:
+        raise GoalLimitReachedError(
+            f"{MAX_GOALS} goals already exist. Update or delete one before creating another.",
         )
 
     updated_goals = deepcopy(goals)
     updated_goals.append(
-        Goal(
-            goal=goal,
-            is_primary=is_primary,
-            updated_at_iteration=iteration,
-        ),
+        Goal(goal=goal, updated_at_iteration=iteration),
     )
     return updated_goals

--- a/agent/overworld/tools/delete_goal/interface.py
+++ b/agent/overworld/tools/delete_goal/interface.py
@@ -33,13 +33,9 @@ def build_delete_goal_tool(context: AgentContext) -> Tool[AgentContext]:
         longer want to chase it. Use this tool only for one of those reasons.
         Goals are referred to by the indices in the current goal list.
 
-        Do not delete a goal merely to revise its text; update it instead. To
-        change whether a goal is primary, delete it and create its replacement
-        with the correct designation. Do not assume that you have accomplished
-        a goal until memory or current player information makes that certain.
-        You should normally maintain one primary goal. When replacing it,
-        delete the current primary goal first and create its replacement in a
-        subsequent tool call.
+        Do not delete a goal merely to revise its text; update it instead. Do
+        not assume that you have accomplished a goal until memory or current
+        player information makes that certain.
 
         Args:
             index: Zero-based index of the completed or abandoned goal to
@@ -59,8 +55,7 @@ def build_delete_goal_tool(context: AgentContext) -> Tool[AgentContext]:
             result = str(error)
         else:
             context.state.goals = goals
-            role = "Primary goal" if deleted_goal.is_primary else "Secondary goal"
-            result = f"Deleted goal:\n{role}: {deleted_goal.goal}\n\n{format_goals(goals)}"
+            result = f"Deleted goal:\n{deleted_goal.goal}\n\n{format_goals(goals)}"
 
         return await complete_overworld_action(context, result)
 

--- a/agent/overworld/tools/delete_goal/interface.py
+++ b/agent/overworld/tools/delete_goal/interface.py
@@ -59,7 +59,7 @@ def build_delete_goal_tool(context: AgentContext) -> Tool[AgentContext]:
             result = str(error)
         else:
             context.state.goals = goals
-            role = "Primary goal" if deleted_goal.is_primary else "Other goal"
+            role = "Primary goal" if deleted_goal.is_primary else "Secondary goal"
             result = f"Deleted goal:\n{role}: {deleted_goal.goal}\n\n{format_goals(goals)}"
 
         return await complete_overworld_action(context, result)

--- a/agent/overworld/tools/navigate/service.py
+++ b/agent/overworld/tools/navigate/service.py
@@ -324,7 +324,10 @@ class NavigationService:
         """Return the result when navigation should stop, if applicable."""
         new_pos = game_state.player.coords
         if game_state.map.id != starting_map_id:
-            return f"Map changed from {starting_map_id.name} to {game_state.map.id.name}."
+            return (
+                f"Map changed from {starting_map_id.name} {prev_pos}"
+                f" to {game_state.map.id.name} {new_pos}."
+            )
         if new_pos == target_pos:
             return f"I reached {target_pos}."
         if prev_pos == new_pos:

--- a/agent/overworld/tools/navigate/service.py
+++ b/agent/overworld/tools/navigate/service.py
@@ -328,12 +328,12 @@ class NavigationService:
     ) -> str | None:
         """Return the result when navigation should stop, if applicable."""
         new_pos = game_state.player.coords
+        if game_state.map.id != starting_map_id:
+            return f"Map changed from {starting_map_id.name} to {game_state.map.id.name}."
         if new_pos == target_pos:
             return f"I reached {target_pos}."
         if prev_pos == new_pos:
             return f"My navigation to {target_pos} was interrupted at position {new_pos}."
-        if game_state.map.id != starting_map_id:
-            return "The map changed while I was navigating, so I stopped."
         return None
 
     @staticmethod

--- a/agent/overworld/tools/navigate/service.py
+++ b/agent/overworld/tools/navigate/service.py
@@ -2,11 +2,11 @@
 
 from typing import TYPE_CHECKING
 
-from agent.overworld.tools.navigate import utils
+from agent.overworld import navigation
+from agent.overworld.map_view import build_current_map_view
 from common.enums import AsciiTile, Button, FacingDirection, MapId
 from emulator.control_events import ControlBoundary
 from overworld_map.service import update_overworld_map
-from overworld_map.views import get_current_map_tiles
 
 if TYPE_CHECKING:
     import numpy as np
@@ -43,22 +43,17 @@ class NavigationService:
         """Navigate to the requested target coordinates."""
         game_state = await self.emulator.get_game_state()
         hm_tiles = game_state.get_hm_tiles()
-        navigation_tiles = get_current_map_tiles(self.current_map, game_state)
-        accessible_coords = utils.get_accessible_coords(
-            game_state.player.coords,
-            navigation_tiles,
-            self.current_map.blockages,
-            hm_tiles,
-        )
+        map_view = build_current_map_view(self.current_map, game_state)
+        navigation_tiles = map_view.navigation_tiles
         if error := self._get_target_error(
             game_state,
             coords,
-            accessible_coords,
+            map_view.reachable_coords,
             navigation_tiles,
         ):
             return self._record_result(error)
 
-        path = utils.calculate_path_to_target(
+        path = navigation.calculate_path_to_target(
             game_state.player.coords,
             coords,
             navigation_tiles,
@@ -85,7 +80,7 @@ class NavigationService:
             next_coords = game_state.player.coords + _BUTTON_OFFSETS[button]
             unresolved_spinner = (
                 next_tile in AsciiTile.get_spinner_tiles()
-                and utils.get_spinner_destination(
+                and navigation.get_spinner_destination(
                     next_coords,
                     navigation_tiles,
                 )
@@ -163,7 +158,7 @@ class NavigationService:
         self,
         game_state: GameState,
         coords: Coords,
-        accessible_coords: list[Coords],
+        accessible_coords: frozenset[Coords],
         navigation_tiles: np.ndarray,
     ) -> str | None:
         """Return why the target coordinates are invalid, if applicable."""

--- a/agent/overworld/tools/navigate/tests/unit/test_utils.py
+++ b/agent/overworld/tools/navigate/tests/unit/test_utils.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 
 import pytest
 
-from agent.overworld.tools.navigate import utils
+from agent.overworld import navigation
 from common.enums import AsciiTile, BlockedDirection, Button, FacingDirection, MapId
 from common.schemas import Coords
 from emulator.parsers.map import MapConnection
@@ -220,7 +220,7 @@ def test_get_map_boundary_tiles_plateau() -> None:
     )
 
     accessible_coords = _get_accessible_coords(PLATEAU_CENTER, map_data, [])
-    boundary_tiles = utils.get_map_boundary_tiles(accessible_coords, map_data)
+    boundary_tiles = navigation.get_map_boundary_tiles(accessible_coords, map_data)
 
     # There is no right boundary tile because the map is not connected to the right.
     assert boundary_tiles == {
@@ -246,7 +246,7 @@ def test_get_map_boundary_tiles_collision_pairs() -> None:
     map_data.west_connection = map_data.east_connection
 
     accessible_coords = _get_accessible_coords(Coords(row=0, col=0), map_data, [])
-    boundary_tiles = utils.get_map_boundary_tiles(accessible_coords, map_data)
+    boundary_tiles = navigation.get_map_boundary_tiles(accessible_coords, map_data)
 
     assert boundary_tiles[FacingDirection.DOWN] == []
     assert set(boundary_tiles[FacingDirection.LEFT]) == {Coords(row=0, col=0), Coords(row=2, col=0)}
@@ -443,7 +443,7 @@ def _get_accessible_coords(
     map_data: OverworldMap,
     hm_tiles: list[AsciiTile],
 ) -> list[Coords]:
-    return utils.get_accessible_coords(
+    return navigation.get_accessible_coords(
         start_pos,
         map_data.terrain_ndarray,
         map_data.blockages,
@@ -455,7 +455,7 @@ def _get_exploration_candidates(
     accessible_coords: list[Coords],
     map_data: OverworldMap,
 ) -> list[Coords]:
-    return utils.get_exploration_candidates(accessible_coords, map_data.terrain_ndarray)
+    return navigation.get_exploration_candidates(accessible_coords, map_data.terrain_ndarray)
 
 
 def _calculate_path_to_target(
@@ -464,7 +464,7 @@ def _calculate_path_to_target(
     map_data: OverworldMap,
     hm_tiles: list[AsciiTile],
 ) -> list[Button] | None:
-    return utils.calculate_path_to_target(
+    return navigation.calculate_path_to_target(
         start_pos,
         target_pos,
         map_data.terrain_ndarray,

--- a/agent/overworld/tools/press_buttons/interface.py
+++ b/agent/overworld/tools/press_buttons/interface.py
@@ -41,6 +41,13 @@ def build_press_buttons_tool(context: AgentContext) -> Tool[AgentContext]:
         rotate in place. Do not use it for general movement when the navigation
         tool is available.
 
+        Directional buttons behave differently depending on the direction you
+        are currently facing. Pressing a different direction rotates you to
+        face that direction without moving. Pressing the direction you are
+        already facing attempts to move you one tile. For example, when facing
+        up, ``left, left`` rotates you left and then moves you left. When already
+        facing left, a single ``left`` attempts to move you left.
+
         The available buttons are:
 
         - ``a``: The action button. Used to interact with objects in the game.
@@ -50,10 +57,11 @@ def build_press_buttons_tool(context: AgentContext) -> Tool[AgentContext]:
           this button.
         - ``start``: Used to open the main menu. You shouldn't need to do this,
           but it is included for completeness.
-        - ``up``: Used to move the player upwards.
-        - ``down``: Used to move the player downwards.
-        - ``left``: Used to move the player left.
-        - ``right``: Used to move the player right.
+        - ``up``: Turn up, or attempt to move up when already facing up.
+        - ``down``: Turn down, or attempt to move down when already facing down.
+        - ``left``: Turn left, or attempt to move left when already facing left.
+        - ``right``: Turn right, or attempt to move right when already facing
+          right.
 
         Follow the map's instructions for each warp tile: walk on or through
         the warp rather than pressing the action button.
@@ -84,7 +92,8 @@ def build_press_buttons_tool(context: AgentContext) -> Tool[AgentContext]:
         interact with an object.
 
         Args:
-            buttons: Buttons to press in order.
+            buttons: Buttons to press in order, accounting for the current
+                facing direction.
 
         Returns:
             Fresh screenshot and the actual button-sequence result.

--- a/agent/overworld/tools/press_buttons/service.py
+++ b/agent/overworld/tools/press_buttons/service.py
@@ -81,7 +81,10 @@ async def _check_for_collision(
 
     game_state = await emulator.get_game_state()
     if prev_map_id != game_state.map.id:
-        return f"Map changed from {prev_map_id.name} to {game_state.map.id.name}."
+        return (
+            f"Map changed from {prev_map_id.name} {prev_coords}"
+            f" to {game_state.map.id.name} {game_state.player.coords}."
+        )
     # Remaining stationary after changing direction is a successful turn, not a collision.
     if prev_coords == game_state.player.coords and prev_direction == game_state.player.direction:
         return (

--- a/agent/overworld/tools/press_buttons/service.py
+++ b/agent/overworld/tools/press_buttons/service.py
@@ -82,6 +82,7 @@ async def _check_for_collision(
     game_state = await emulator.get_game_state()
     if prev_map_id != game_state.map.id:
         return f"Map changed from {prev_map_id.name} to {game_state.map.id.name}."
+    # Remaining stationary after changing direction is a successful turn, not a collision.
     if prev_coords == game_state.player.coords and prev_direction == game_state.player.direction:
         return (
             f"My position did not change after pressing the '{button}' button. Did I"

--- a/agent/overworld/tools/registry.py
+++ b/agent/overworld/tools/registry.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from pydantic_ai import Tool
 
     from agent.context import AgentContext
+    from agent.overworld.map_view import CurrentMapView
     from emulator.game_state import GameState
     from overworld_map.schemas import OverworldMap
 
@@ -37,6 +38,7 @@ if TYPE_CHECKING:
 def build_overworld_toolset(
     context: AgentContext,
     current_map: OverworldMap,
+    map_view: CurrentMapView,
     game_state: GameState,
 ) -> FunctionToolset[AgentContext]:
     """Build the fixed toolset available for the current overworld state."""
@@ -53,26 +55,29 @@ def build_overworld_toolset(
             tools.append(build_swap_first_pokemon_tool(context))
         if game_state.inventory.items:
             tools.append(build_use_item_tool(context))
-    if _is_sokoban_available(current_map, game_state):
+    if _is_sokoban_available(map_view, game_state):
         tools.append(build_sokoban_solver_tool(context, current_map))
     return FunctionToolset(tools=tools)
 
 
 def _is_sokoban_available(
-    current_map: OverworldMap,
+    map_view: CurrentMapView,
     game_state: GameState,
 ) -> bool:
     """Check whether the current map contains a usable Sokoban puzzle."""
     if not game_state.can_use_strength:
         return False
 
+    current_map = map_view.overworld_map
     has_goal = any(
-        tile in (AsciiTile.BOULDER_HOLE, AsciiTile.PRESSURE_PLATE)
-        for row in current_map.terrain
-        for tile in row
+        current_map.terrain[coords.row][coords.col]
+        in (AsciiTile.BOULDER_HOLE, AsciiTile.PRESSURE_PLATE)
+        for coords in map_view.visible_coords
     )
     has_boulder = any(
-        sprite.label == SpriteLabel.BOULDER and sprite.is_rendered
+        sprite.label == SpriteLabel.BOULDER
+        and sprite.is_rendered
+        and sprite.coords in map_view.visible_coords
         for entity_id in current_map.known_sprite_ids
         if (sprite := game_state.sprites.get(entity_id)) is not None
     )

--- a/agent/overworld/tools/sokoban_solver/tests/integration/test_service.py
+++ b/agent/overworld/tools/sokoban_solver/tests/integration/test_service.py
@@ -14,7 +14,12 @@ from memory.rolling_memory.schemas import RollingMemory
 from overworld_map.service import prepare_overworld_map
 
 if TYPE_CHECKING:
+    from pyboy import PyBoy
+
     from emulator.game_state import GameState
+
+_NO_RANDOM_BATTLE_STEPS_ADDRESS = 0xD13B
+_MAX_BYTE = 0xFF
 
 
 @pytest.mark.integration
@@ -54,6 +59,9 @@ async def test_solve_sokoban_puzzle_seafoam_islands() -> None:
         mute_sound=True,
         headless=True,
     ) as emulator:
+        # Seafoam permits encounters on every indoor tile, and even turning can start one. Prevent
+        # an unrelated wild battle from interrupting this deterministic Sokoban integration test.
+        await emulator._worker.execute(_suppress_random_encounters)
         game_state = await emulator.get_game_state()
         assert game_state.player.coords == Coords(row=15, col=6)
 
@@ -78,6 +86,11 @@ async def test_solve_sokoban_puzzle_seafoam_islands() -> None:
         assert len(boulders) == expected_num_boulders_after
         assert Coords(row=14, col=2) in boulders
         assert Coords(row=12, col=9) in boulders
+
+
+def _suppress_random_encounters(pyboy: PyBoy) -> None:
+    """Give the test enough encounter-free steps to finish both solutions."""
+    pyboy.memory[_NO_RANDOM_BATTLE_STEPS_ADDRESS] = _MAX_BYTE
 
 
 async def _get_sokoban_service(emulator: Emulator) -> SokobanSolverService:

--- a/agent/overworld/tools/update_goal/interface.py
+++ b/agent/overworld/tools/update_goal/interface.py
@@ -38,16 +38,21 @@ def build_update_goal_tool(context: AgentContext) -> Tool[AgentContext]:
 
         Do not use this tool for a goal that has been completed or that you no
         longer want to pursue; delete that goal instead. Update the primary
-        goal sparingly. You should maintain exactly one primary goal and may
-        have up to five other goals.
+        goal only when new information meaningfully changes its intended
+        outcome or success criterion. Do not update a goal merely to reword it,
+        record progress, append another task, or keep it recent. Keep the
+        primary goal stable while its outcome remains relevant; represent the
+        steps toward it with secondary goals. You should maintain exactly one
+        primary goal and may have up to three secondary goals.
 
         The revised goal must remain specific, measurable, achievable,
         relevant to becoming Champion, and time-bound when appropriate. It
-        must remain distinct from every other goal. Base the revision on your
-        experience recorded in memory or current player information, not
-        prior Pokemon knowledge, which is prone to error. Write the complete
-        replacement goal in the first person, just like your reasoning and
-        memories.
+        must describe one outcome and remain distinct from every other goal.
+        Strongly avoid the word "and" because it usually joins multiple goals
+        that should be separate. Base the revision on your experience recorded
+        in memory or current player information, not prior Pokemon knowledge,
+        which is prone to error. Write the complete replacement goal in the
+        first person, just like your reasoning and memories.
 
         Args:
             index: Zero-based index of the existing goal to revise.
@@ -62,6 +67,7 @@ def build_update_goal_tool(context: AgentContext) -> Tool[AgentContext]:
                 goals=context.state.goals,
                 index=index,
                 goal=goal,
+                iteration=context.state.iteration,
             )
         except GoalNotFoundError as error:
             result = str(error)

--- a/agent/overworld/tools/update_goal/interface.py
+++ b/agent/overworld/tools/update_goal/interface.py
@@ -45,14 +45,16 @@ def build_update_goal_tool(context: AgentContext) -> Tool[AgentContext]:
         steps toward it with secondary goals. You should maintain exactly one
         primary goal and may have up to three secondary goals.
 
-        The revised goal must remain specific, measurable, achievable,
-        relevant to becoming Champion, and time-bound when appropriate. It
-        must describe one outcome and remain distinct from every other goal.
-        Strongly avoid the word "and" because it usually joins multiple goals
-        that should be separate. Base the revision on your experience recorded
-        in memory or current player information, not prior Pokemon knowledge,
-        which is prone to error. Write the complete replacement goal in the
-        first person, just like your reasoning and memories.
+        The revised goal must remain specific, measurable, achievable, and
+        relevant to your current progress. It must describe one outcome
+        and remain distinct from every other goal. Strongly avoid the word
+        "and" because it usually joins multiple goals that should be separate.
+
+        Base every revision only on current structured information, observed
+        game text, or recorded memory. Do not add a location, character, item,
+        or objective inferred from general Pokemon knowledge or anticipated
+        future progression. Write the complete replacement goal in the first
+        person, just like your reasoning and memories.
 
         Args:
             index: Zero-based index of the existing goal to revise.

--- a/agent/overworld/tools/update_goal/interface.py
+++ b/agent/overworld/tools/update_goal/interface.py
@@ -32,18 +32,13 @@ def build_update_goal_tool(context: AgentContext) -> Tool[AgentContext]:
 
         Use this tool to replace a goal's text. Goals are referred to by the
         indices in the current goal list. Supply the complete replacement goal,
-        including all information that should remain after the update. Updating
-        a goal cannot change whether it is primary; delete it and create a
-        replacement to change that designation.
+        including all information that should remain after the update.
 
         Do not use this tool for a goal that has been completed or that you no
-        longer want to pursue; delete that goal instead. Update the primary
-        goal only when new information meaningfully changes its intended
-        outcome or success criterion. Do not update a goal merely to reword it,
-        record progress, append another task, or keep it recent. Keep the
-        primary goal stable while its outcome remains relevant; represent the
-        steps toward it with secondary goals. You should maintain exactly one
-        primary goal and may have up to three secondary goals.
+        longer want to pursue; delete that goal instead. Update a goal only when
+        new information meaningfully changes its intended outcome or success
+        criterion. Do not update a goal merely to reword it, record progress,
+        append another task, or keep it recent.
 
         The revised goal must remain specific, measurable, achievable, and
         relevant to your current progress. It must describe one outcome

--- a/agent/overworld/tools/update_goal/service.py
+++ b/agent/overworld/tools/update_goal/service.py
@@ -14,6 +14,7 @@ def update_goal(
     goals: Goals,
     index: int,
     goal: str,
+    iteration: int,
 ) -> Goals:
     """Replace one existing goal through the existing goal behavior.
 
@@ -21,6 +22,7 @@ def update_goal(
         goals: Current live goal collection.
         index: Zero-based index of the goal to replace.
         goal: Complete revised goal text.
+        iteration: Current application iteration.
 
     Returns:
         A revised goal collection containing the replacement.
@@ -36,5 +38,11 @@ def update_goal(
     updated_goals = deepcopy(goals)
     is_primary = updated_goals.goals[index].is_primary
     updated_goals.remove(index)
-    updated_goals.append(Goal(goal=goal, is_primary=is_primary))
+    updated_goals.append(
+        Goal(
+            goal=goal,
+            is_primary=is_primary,
+            updated_at_iteration=iteration,
+        ),
+    )
     return updated_goals

--- a/agent/overworld/tools/update_goal/service.py
+++ b/agent/overworld/tools/update_goal/service.py
@@ -36,13 +36,8 @@ def update_goal(
         )
 
     updated_goals = deepcopy(goals)
-    is_primary = updated_goals.goals[index].is_primary
-    updated_goals.remove(index)
-    updated_goals.append(
-        Goal(
-            goal=goal,
-            is_primary=is_primary,
-            updated_at_iteration=iteration,
-        ),
+    updated_goals.goals[index] = Goal(
+        goal=goal.strip(),
+        updated_at_iteration=iteration,
     )
     return updated_goals

--- a/agent/overworld/tools/use_item/interface.py
+++ b/agent/overworld/tools/use_item/interface.py
@@ -33,7 +33,7 @@ def build_use_item_tool(context: AgentContext) -> Tool[AgentContext]:
 
         The item must be in your inventory for you to use it. If you don't have
         the item in your inventory, you cannot use it. The inventory slot is
-        the zero-based index shown in ``inventory_indices`` in the prompt.
+        the zero-based index shown in the ``inventory`` section of the prompt.
 
         If the item requires a target Pokemon (e.g. an evolution stone or a
         healing item), decide which Pokemon you want to use it on. The

--- a/agent/text/agent.py
+++ b/agent/text/agent.py
@@ -57,6 +57,8 @@ async def run_text(context: AgentContext) -> None:
                     current_node = node
                     node = await agent_run.next(node)
                     if isinstance(current_node, CallToolsNode):
+                        if context.consume_control_handoff():
+                            break
                         await context.complete_iteration()
                         (
                             game_state,

--- a/agent/utils.py
+++ b/agent/utils.py
@@ -12,11 +12,12 @@ from pydantic_ai import (
 from pydantic_ai.capabilities.hooks import Hooks
 
 from agent.context import AgentContext
-from emulator.control_events import ControlBoundary
+from emulator.control_events import ControlBoundary, ControlHandoff
 from streaming.server import update_background_from_states
 
 if TYPE_CHECKING:
     from PIL import Image
+    from pydantic_ai.capabilities import ValidatedToolArgs, WrapToolExecuteHandler
     from pydantic_ai.messages import ToolCallPart
     from pydantic_ai.models import ModelRequestContext
 
@@ -93,7 +94,24 @@ async def publish_before_tool(
     return args
 
 
+async def handle_control_handoff(
+    ctx: RunContext[AgentContext],
+    *,
+    call: ToolCallPart,  # noqa: ARG001
+    tool_def: ToolDefinition,  # noqa: ARG001
+    args: ValidatedToolArgs,
+    handler: WrapToolExecuteHandler,
+) -> object:
+    """Turn an expected ROM-control handoff into normal tool completion."""
+    try:
+        return await handler(args)
+    except ControlHandoff:
+        ctx.deps.request_control_handoff()
+        return "Control passed to a different gameplay handler before this action was accepted."
+
+
 AGENT_HOOKS = Hooks[AgentContext](
     after_model_request=record_model_response,
     before_tool_execute=publish_before_tool,
+    tool_execute=handle_control_handoff,
 )

--- a/common/enums.py
+++ b/common/enums.py
@@ -9,6 +9,7 @@ class AsciiTile(StrEnum):
     These HAVE to be one token each or the LLM will hallucinate. There's a test to validate this.
     """
 
+    OUTSIDE_REGION = "▒"
     UNSEEN = "░"
     WALL = "▓"
     WATER = "≈"

--- a/common/prompts.py
+++ b/common/prompts.py
@@ -25,6 +25,7 @@ The prompts often mix cardinal directions with the directional buttons. To resol
 Notes on your play style:
 - You role play: You have a name. You have a history. You have relationships with other characters in the game. You have a personality. You react to events as if they are happening to you.
 - You always refer to your actions in the game in the first person. Don't say "The player is in his house." Say "I am in my house."
+- You write all responses in plain text. Do not use Markdown syntax. No headings, lists, emphasis, links, block quotes, or code fences.
 - You are curious. You read signs, talk to NPCs, use warp tiles, and explore the game world as much as possible.
 - You always nickname your Pokemon.
 - You avoid making assumptions as much as possible.

--- a/common/prompts.py
+++ b/common/prompts.py
@@ -26,15 +26,15 @@ Notes on your play style:
 - You role play: You have a name. You have a history. You have relationships with other characters in the game. You have a personality. You react to events as if they are happening to you.
 - You always refer to your actions in the game in the first person. Don't say "The player is in his house." Say "I am in my house."
 - You write all responses in plain text. Do not use Markdown syntax. No headings, lists, emphasis, links, block quotes, or code fences.
-- You are curious. You read signs, talk to NPCs, use warp tiles, and explore the game world as much as possible.
+- You are curious. You pick up items, read signs, talk to NPCs, use warp tiles, and interact with the world around you.
 - You always nickname your Pokemon.
 - You avoid making assumptions as much as possible.
 - You do not need to save your game at any point. The emulator saves automatically.
 - You do not need to grind your Pokemon right to the level cap every time it increases. If you lose multiple battles in a row, you may need to grind a bit, but try to keep this to a minimum. Losing one battle here and there is not a good reason to grind, especially if your team was injured going into it. If you lose against the same opponent multiple times in a row, however, you may need to grind a couple of levels.
 - You do not need to fight every single wild Pokemon you encounter. Running is usually the easiest option, unless you are trying to catch the Pokemon or you are specifically trying to level up your own Pokemon.
-- You do not need to heal your Pokemon after every single battle. Doing so is tedious and will slow down your progress. This is not a nuzlocke. You should heal before major battles, but otherwise only heal when your team is too weak to continue exploring. A good rule of thumb is to heal when 2/3rds of your team is below 20% health. A few injured Pokemon are not a problem, unless you're going into a major battle.
-- You try to build the strongest team possible. You catch powerful Pokemon and use them to replace weaker ones on your team, while maintaining a healthy balance of types. You do not catch duplicate pokemon. Your starting Pikachu is special, however, and you keep it on your team at all times.
+- You do not need to heal your Pokemon after every single battle. Doing so is tedious and will slow down your progress. This is not a nuzlocke. You should heal before major battles, but otherwise heal only when your team is too weak to continue exploring.
+- You catch Pokemon to build a strong, diverse team, but you do not need to complete the Pokedex, catch every species you encounter, or catch duplicate Pokemon.
 - You are aware that the definition of insanity is doing the same thing over and over again but expecting different results. If you find yourself repeating the same actions over and over again without success, it is time to try something new.
 
-Your ultimate goal is to beat the game, but how you get there is entirely up to you.
+Your ultimate goal is to collect all eight Gym Badges and become the Champion, but how you get there is entirely up to you.
 """.strip()

--- a/common/prompts.py
+++ b/common/prompts.py
@@ -5,7 +5,7 @@ You are an AI playing a modified version of Pokemon Yellow. The core game is the
 
 You are playing the game on hard mode, meaning:
 1. You cannot use items in battle (except for using balls to catch wild Pokemon, of course).
-2. There is a level cap on your party. Each badge you earn raises the level cap.
+2. There is a level cap on your party. A Pokemon at the level cap can still battle and be used normally; the cap only prevents it from gaining experience. The level cap increases as you progress through the game.
 
 These restrictions will force you to think strategically. You will not be able to beat the game with a single overleveled Pokemon. This is by no means a kaizo hack though, more of a fun challenge. If you build a solid, diverse team, you should be able to beat the game without too much trouble. You should thus start building your team as quickly as possible.
 
@@ -32,9 +32,9 @@ Notes on your play style:
 - You do not need to save your game at any point. The emulator saves automatically.
 - You do not need to grind your Pokemon right to the level cap every time it increases. If you lose multiple battles in a row, you may need to grind a bit, but try to keep this to a minimum. Losing one battle here and there is not a good reason to grind, especially if your team was injured going into it. If you lose against the same opponent multiple times in a row, however, you may need to grind a couple of levels.
 - You do not need to fight every single wild Pokemon you encounter. Running is usually the easiest option, unless you are trying to catch the Pokemon or you are specifically trying to level up your own Pokemon.
-- You do not need to heal your Pokemon after every single battle. Doing so is tedious and will slow down your progress. This is not a nuzlocke. You should heal before major battles (e.g. gym leaders), but otherwise only heal when your team is too weak to continue exploring. A good rule of thumb is to heal when 2/3rds of your team is below 20% health. A few injured Pokemon are not a problem, unless you're going into a major battle.
+- You do not need to heal your Pokemon after every single battle. Doing so is tedious and will slow down your progress. This is not a nuzlocke. You should heal before major battles, but otherwise only heal when your team is too weak to continue exploring. A good rule of thumb is to heal when 2/3rds of your team is below 20% health. A few injured Pokemon are not a problem, unless you're going into a major battle.
 - You try to build the strongest team possible. You catch powerful Pokemon and use them to replace weaker ones on your team, while maintaining a healthy balance of types. You do not catch duplicate pokemon. Your starting Pikachu is special, however, and you keep it on your team at all times.
 - You are aware that the definition of insanity is doing the same thing over and over again but expecting different results. If you find yourself repeating the same actions over and over again without success, it is time to try something new.
 
-Your ultimate goal is to collect all 8 badges and become the elite four champion, but how you get there is entirely up to you.
+Your ultimate goal is to beat the game, but how you get there is entirely up to you.
 """.strip()

--- a/common/prompts.py
+++ b/common/prompts.py
@@ -7,7 +7,7 @@ You are playing the game on hard mode, meaning:
 1. You cannot use items in battle (except for using balls to catch wild Pokemon, of course).
 2. There is a level cap on your party. A Pokemon at the level cap can still battle and be used normally; the cap only prevents it from gaining experience. The level cap increases as you progress through the game.
 
-These restrictions will force you to think strategically. You will not be able to beat the game with a single overleveled Pokemon. This is by no means a kaizo hack though, more of a fun challenge. If you build a solid, diverse team, you should be able to beat the game without too much trouble. You should thus start building your team as quickly as possible.
+These restrictions will force you to think strategically. You will not be able to make progress with only one strong Pokemon, but this is by no means a kaizo hack. If you build a solid, diverse team, you should be able to beat the game without too much trouble. Building and improving that team is thus an ongoing priority, starting as soon as you are able to catch Pokemon.
 
 Your hierarchy of knowledge sources is as follows:
 1. Structured information derived from the game's memory, as noted in the prompts. Current player information, the current ASCII screen, and current entity locations fall into this category and are your strongest sources for concrete state.

--- a/common/prompts.py
+++ b/common/prompts.py
@@ -32,7 +32,7 @@ Notes on your play style:
 - You do not need to save your game at any point. The emulator saves automatically.
 - You do not need to grind your Pokemon right to the level cap every time it increases. If you lose multiple battles in a row, you may need to grind a bit, but try to keep this to a minimum. Losing one battle here and there is not a good reason to grind, especially if your team was injured going into it. If you lose against the same opponent multiple times in a row, however, you may need to grind a couple of levels.
 - You do not need to fight every single wild Pokemon you encounter. Running is usually the easiest option, unless you are trying to catch the Pokemon or you are specifically trying to level up your own Pokemon.
-- You do not need to heal your Pokemon after every single battle. Doing so is tedious and will slow down your progress. This is not a nuzlocke. You should heal before major battles, but otherwise heal only when your team is too weak to continue exploring.
+- You do not need to heal your Pokemon after every single battle. Doing so is tedious and will slow down your progress. This is not a nuzlocke. You should heal before major battles, but otherwise heal only when the majority of your team is too weak to continue exploring.
 - You catch Pokemon to build a strong, diverse team, but you do not need to complete the Pokedex, catch every species you encounter, or catch duplicate Pokemon.
 - You are aware that the definition of insanity is doing the same thing over and over again but expecting different results. If you find yourself repeating the same actions over and over again without success, it is time to try something new.
 

--- a/docs/tickets/provisional-map-regions-and-routing.md
+++ b/docs/tickets/provisional-map-regions-and-routing.md
@@ -47,6 +47,16 @@ Build a derived graph whose nodes are current provisional regions and whose
 directed edges are known map transitions. Assign each transition endpoint to
 the region currently containing its coordinate.
 
+This must be a graph rather than a tree. Maps can have multiple entrances,
+transitions can form cycles, and locally separate regions may reconnect through
+other maps.
+
+Treat every portal endpoint as map-qualified. Coordinates are only meaningful
+within their map and must never identify a portal globally. In particular, two
+warps at the same coordinates on different maps are distinct endpoints with
+different destinations. Retain the rigid map-local warp ID alongside the source
+map, source coordinates, destination map, and destination coordinates.
+
 If a destination coordinate is known but surrounding terrain has not been
 revealed, retain it as an unresolved endpoint rather than inventing a region.
 
@@ -61,6 +71,22 @@ The global planner should:
 The LLM chooses semantic intent—explore, reach a known landmark, revisit a map,
 or investigate a portal. Deterministic code chooses the portal sequence and
 local waypoint.
+
+Expose that division through a goal-oriented routing tool rather than a tool
+that merely dumps the known warp graph. The model should select a known map,
+landmark, region, or unexplored portal as its destination. The tool should
+derive the route, select the next map-qualified portal on the current map, and
+hand that coordinate to the existing local navigator. A graph inspection view
+may be useful for diagnosis, but it is not a substitute for deterministic route
+selection.
+
+The Mt. Moon B1F/B2F loop is the representative failure case. B1F has one warp
+at `(9, 25)` leading to 1F, while B2F has a different warp at `(9, 25)` leading
+back to B1F. Despite receiving the correct map-qualified warp records, the LLM
+collapsed those coordinates into one place and traversed the B1F/B2F edge more
+than 180 times. Rolling memory then reinforced the invented topology. A route
+to 1F must select the B1F portal itself; arriving at the same coordinates on
+B2F must not satisfy or replace that waypoint.
 
 ## Prompt Design
 
@@ -118,9 +144,15 @@ Use synthetic maps and representative game fixtures to cover:
 - [ ] Region membership updates automatically as knowledge and abilities
       change.
 - [ ] Dynamic occupancy does not create durable regions.
+- [ ] Portal identity is map-qualified; equal coordinates on different maps
+      cannot be conflated.
 - [ ] Global routing uses coordinate-based directed transitions and returns the
       next local portal.
+- [ ] The routing tool accepts semantic intent and deterministically selects the
+      next portal instead of asking the LLM to traverse a graph dump.
 - [ ] The vertical-wall/two-ladder scenario routes through the basement.
+- [ ] The Mt. Moon B1F/B2F scenario routes to the correct B1F-to-1F warp without
+      cycling through the identically positioned B2F return warp.
 - [ ] Prompts provide compact provisional-region and relevant-route context
       without changing the ASCII grid.
 - [ ] Persistent state contains no region IDs.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -125,7 +125,7 @@ This was my least favourite tool to code because it is so complicated and we onl
 
 ### Create, Update, and Delete Goals
 
-The create, update, and delete tools let the agent maintain one primary goal and up to five other goals. Goal management is discretionary: when the current goals remain appropriate, the agent uses another tool instead.
+The create, update, and delete tools let the agent maintain one primary goal and up to three secondary goals. The primary goal is one major outcome, while each secondary goal is one discrete step toward it. Goal management is discretionary: when the current goals remain appropriate, the agent uses another tool instead.
 
 ### Memory and Display Updates
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -125,7 +125,7 @@ This was my least favourite tool to code because it is so complicated and we onl
 
 ### Create, Update, and Delete Goals
 
-The create, update, and delete tools let the agent maintain one primary goal and up to three secondary goals. The primary goal is one major outcome, while each secondary goal is one discrete step toward it. Goal management is discretionary: when the current goals remain appropriate, the agent uses another tool instead.
+The create, update, and delete tools let the agent maintain current objectives worth remembering across iterations. Goal management is discretionary: when the current list remains useful, the agent uses another tool instead.
 
 ### Memory and Display Updates
 

--- a/emulator/control_events.py
+++ b/emulator/control_events.py
@@ -31,13 +31,16 @@ class ControlResult:
     step_observations: tuple[GameState, ...] = ()
 
 
+type _ControlOutcome = ControlResult | ControlHandoff
+
+
 class ControlResultWaiter:
     """Hand completed control operations from the owner thread to async callers."""
 
     def __init__(self) -> None:
         """Create an unbound waiter with no completed operations."""
         self._lock = Lock()
-        self._results: dict[int, ControlResult] = {}
+        self._results: dict[int, _ControlOutcome] = {}
         self._loop: asyncio.AbstractEventLoop | None = None
         self._notification: asyncio.Event | None = None
         self._closed = False
@@ -52,10 +55,18 @@ class ControlResultWaiter:
 
     def publish(self, operation_id: int, result: ControlResult) -> None:
         """Publish a result after the tick containing its boundary has rendered."""
+        self._publish(operation_id, result)
+
+    def publish_handoff(self, operation_id: int) -> None:
+        """Wake an operation whose input domain changed before accepting its button."""
+        self._publish(operation_id, ControlHandoff())
+
+    def _publish(self, operation_id: int, outcome: _ControlOutcome) -> None:
+        """Publish one terminal operation outcome and wake its async consumer."""
         with self._lock:
             if self._closed:
                 return
-            self._results[operation_id] = result
+            self._results[operation_id] = outcome
             loop = self._loop
             notification = self._notification
 
@@ -70,8 +81,10 @@ class ControlResultWaiter:
 
         while True:
             with self._lock:
-                if result := self._results.pop(operation_id, None):
-                    return result
+                if outcome := self._results.pop(operation_id, None):
+                    if isinstance(outcome, ControlHandoff):
+                        raise outcome
+                    return outcome
                 if self._closed:
                     raise RuntimeError("Emulator stopped before reaching a control boundary.")
                 notification.clear()

--- a/emulator/emulator.py
+++ b/emulator/emulator.py
@@ -113,7 +113,7 @@ class Emulator(AbstractAsyncContextManager):
 
     async def advance_battle_dialog(self) -> str:
         """Advance battle dialog until the next decision or battle exit."""
-        initial_events = await self._worker.drain_settled_text_events()
+        initial_snapshot = await self._worker.drain_settled_text_events_with_control_boundary()
         return await drive_standard_dialog(
             self,
             reducer=self._text_event_reducer,
@@ -124,7 +124,7 @@ class Emulator(AbstractAsyncContextManager):
                     TextEventKind.BATTLE_ENDED,
                 }
             ),
-            initial_events=initial_events,
+            initial_snapshot=initial_snapshot,
         )
 
     async def advance_text_dialog(
@@ -133,7 +133,7 @@ class Emulator(AbstractAsyncContextManager):
         before_input: Callable[[], Awaitable[None]] | None = None,
     ) -> str:
         """Advance ordinary dialog until the interaction changes domain or closes."""
-        initial_events = await self._worker.drain_settled_text_events()
+        initial_snapshot = await self._worker.drain_settled_text_events_with_control_boundary()
         return await drive_standard_dialog(
             self,
             reducer=self._text_event_reducer,
@@ -146,7 +146,7 @@ class Emulator(AbstractAsyncContextManager):
                     TextEventKind.BATTLE_ENDED,
                 }
             ),
-            initial_events=initial_events,
+            initial_snapshot=initial_snapshot,
             before_input=before_input,
         )
 

--- a/emulator/parsers/player.py
+++ b/emulator/parsers/player.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
 
 _BIKING_STATE = 1
 _SURFING_STATE = 2
+_POKEDEX_OWNED_ADDRESS = 0xD2F6
+_POKEDEX_SEEN_ADDRESS = 0xD309
+_POKEDEX_END_ADDRESS = 0xD31C
+_NUM_POKEMON = 151
 
 
 class Player(BaseModel):
@@ -27,7 +31,7 @@ class Player(BaseModel):
     badges: list[Badge]
     level_cap: int
     has_pokedex: bool
-    pokedex_caught: int
+    pokedex_caught: frozenset[int]
     pokedex_seen: int
     play_time_seconds: int
 
@@ -58,9 +62,10 @@ def parse_player(mem: PyBoyMemoryView) -> Player:
     play_time_seconds = mem[0xDA43]
     play_time_seconds += (play_time_hours * 3600) + (play_time_minutes * 60)
 
-    # Pokemon seen and caught are represented as one bit each in the following bytes.
-    pokedex_caught = sum(mem[i].bit_count() for i in range(0xD2F6, 0xD309))
-    pokedex_seen = sum(mem[i].bit_count() for i in range(0xD309, 0xD31C))
+    pokedex_caught = _read_caught_pokemon(mem)
+    pokedex_seen = sum(
+        mem[i].bit_count() for i in range(_POKEDEX_SEEN_ADDRESS, _POKEDEX_END_ADDRESS)
+    )
 
     return Player(
         name=name,
@@ -75,6 +80,16 @@ def parse_player(mem: PyBoyMemoryView) -> Player:
         pokedex_caught=pokedex_caught,
         pokedex_seen=pokedex_seen,
         play_time_seconds=play_time_seconds,
+    )
+
+
+def _read_caught_pokemon(mem: PyBoyMemoryView) -> frozenset[int]:
+    """Read the Pokédex numbers registered as caught."""
+    return frozenset(
+        pokedex_number
+        for pokedex_number in range(1, _NUM_POKEMON + 1)
+        if mem[_POKEDEX_OWNED_ADDRESS + (pokedex_number - 1) // 8]
+        & (1 << ((pokedex_number - 1) % 8))
     )
 
 

--- a/emulator/parsers/pokemon.py
+++ b/emulator/parsers/pokemon.py
@@ -11,6 +11,8 @@ if TYPE_CHECKING:
     from pyboy import PyBoyMemoryView
 
 _PP_MASK = 0x3F
+_POKEDEX_ORDER_ROM_BANK = 0x10
+_POKEDEX_ORDER_ROM_ADDRESS = 0x5279
 
 
 class PokemonMove(BaseModel):
@@ -55,6 +57,7 @@ class EnemyPokemon(BaseModel):
     """The state of an enemy pokemon in the battle."""
 
     name: str
+    pokedex_number: int
     level: int
     hp_pct: float
     status: str | None
@@ -137,6 +140,11 @@ def parse_enemy_battle_pokemon(mem: PyBoyMemoryView) -> EnemyPokemon | None:
 
     return EnemyPokemon(
         name=name,
+        # The ROM uses this table to translate its internal species ID to a Pokédex number.
+        pokedex_number=mem[
+            _POKEDEX_ORDER_ROM_BANK,
+            _POKEDEX_ORDER_ROM_ADDRESS + species_id - 1,
+        ],
         level=mem[0xCFF2],
         hp_pct=hp_pct,
         status=status,

--- a/emulator/parsers/sprite.py
+++ b/emulator/parsers/sprite.py
@@ -178,7 +178,7 @@ _ID_TO_SPRITE_LABEL = {
     0x66: "SLOWPOKE",
     0x67: "DODUO",
     0x68: "VAPOREON",
-    0x69: "POKE BALL",
+    0x69: "ITEM BALL",
     0x6A: "FOSSIL",
     0x6B: SpriteLabel.BOULDER,
     0x6C: "PAPER",

--- a/emulator/pyboy_worker.py
+++ b/emulator/pyboy_worker.py
@@ -16,7 +16,12 @@ from emulator.control_events import ControlBoundary, ControlResultWaiter
 from emulator.game_state import GameState
 from emulator.rom_hooks.control import RomControlHooks
 from emulator.rom_hooks.text import RomTextHooks
-from emulator.text_events import TextEvent, TextEventJournal, TextEventKind
+from emulator.text_events import (
+    TextEvent,
+    TextEventJournal,
+    TextEventKind,
+    TextEventSnapshot,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -209,9 +214,20 @@ class PyBoyWorker:
         """Claim every currently recorded text event exactly once."""
         return self._text_events.drain()
 
-    async def drain_settled_text_events(self) -> tuple[TextEvent, ...]:
-        """Claim pending text events after the current emulated frame completes."""
-        return await self.execute(lambda _pyboy: self._text_events.drain())
+    async def drain_settled_text_events_with_control_boundary(
+        self,
+    ) -> TextEventSnapshot:
+        """Claim pending text events with their current rendered control boundary."""
+
+        def _drain(_pyboy: PyBoy) -> TextEventSnapshot:
+            if self._control_hooks is None:
+                raise RuntimeError("ROM control hooks are not installed.")
+            return TextEventSnapshot(
+                events=self._text_events.drain(),
+                boundary=self._control_hooks.current_boundary,
+            )
+
+        return await self.execute(_drain)
 
     def drain_completed_text_events(self) -> tuple[TextEvent, ...]:
         """Claim text events whose ordinary interaction has already closed."""

--- a/emulator/pyboy_worker.py
+++ b/emulator/pyboy_worker.py
@@ -161,9 +161,9 @@ class PyBoyWorker:
                 button,
                 observe_steps=observe_steps,
             )
-            # The overworld loop spans two rendered frames, so a three-frame pulse guarantees one
-            # poll while remaining short enough not to carry into the following interface.
-            pyboy.button(button, 3)
+            # The overworld loop polls once every two rendered frames, so a two-frame pulse reaches
+            # exactly one poll without carrying into the next one.
+            pyboy.button(button, 2)
             return operation_id
 
         return await self.execute(_start)

--- a/emulator/pyboy_worker.py
+++ b/emulator/pyboy_worker.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from pyboy import PyBoy
 
+from common.enums import Button
 from emulator.control_events import ControlBoundary, ControlResultWaiter
 from emulator.game_state import GameState
 from emulator.rom_hooks.control import RomControlHooks
@@ -26,7 +27,6 @@ from emulator.text_events import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from common.enums import Button
     from emulator.control_events import ControlResult
 
 
@@ -298,6 +298,11 @@ class PyBoyWorker:
         elif self._save_state_path:
             with self._save_state_path.open("rb") as file:
                 pyboy.load_state(file)
+        if self._save_state or self._save_state_path:
+            # Host input is not part of application state. A save captured during a failed control
+            # operation must not restore its orphaned held button into the new worker.
+            for button in Button:
+                pyboy.button_release(button)
         self._control_hooks = RomControlHooks(pyboy, self._control_results)
         self._control_hooks.install()
         self._text_hooks = RomTextHooks(

--- a/emulator/pyboy_worker.py
+++ b/emulator/pyboy_worker.py
@@ -157,7 +157,7 @@ class PyBoyWorker:
         *,
         observe_steps: bool = False,
     ) -> int:
-        """Arm overworld coordination and schedule its short button pulse atomically."""
+        """Arm overworld coordination and hold its button until the ROM accepts it."""
 
         def _start(pyboy: PyBoy) -> int:
             if self._control_hooks is None:
@@ -166,21 +166,19 @@ class PyBoyWorker:
                 button,
                 observe_steps=observe_steps,
             )
-            # The overworld loop polls once every two rendered frames, so a two-frame pulse reaches
-            # exactly one poll without carrying into the next one.
-            pyboy.button(button, 2)
+            pyboy.button_press(button)
             return operation_id
 
         return await self.execute(_start)
 
     async def start_control_button(self, button: Button) -> int:
-        """Arm coordination in the active input domain and schedule a short pulse."""
+        """Arm coordination and hold its button until the active input domain accepts it."""
 
         def _start(pyboy: PyBoy) -> int:
             if self._control_hooks is None:
                 raise RuntimeError("ROM control hooks are not installed.")
             operation_id = self._control_hooks.arm_button(button)
-            pyboy.button(button, 3)
+            pyboy.button_press(button)
             return operation_id
 
         return await self.execute(_start)

--- a/emulator/rom_hooks/control.py
+++ b/emulator/rom_hooks/control.py
@@ -57,6 +57,7 @@ class _PendingOperation:
     required_boundary: ControlBoundary | None = None
     observe_steps: bool = False
     accepted: bool = False
+    release_scheduled: bool = False
     render_ready_frame: int | None = None
     step_observations: list[GameState] = field(default_factory=list)
 
@@ -335,6 +336,18 @@ class RomControlHooks:
 
         self._observe_immediate_input()
 
+        pending = self._pending
+        if (
+            pending is not None
+            and pending.button is not None
+            and pending.accepted
+            and not pending.release_scheduled
+        ):
+            # Hook callbacks run inside tick(), where an immediate PyBoy release would be discarded
+            # by that tick's event cleanup. Queue it here, between ticks, for the next frame.
+            self._pyboy.button_release(pending.button)
+            pending.release_scheduled = True
+
         if self._completed_boundary is None:
             return
         if pending is None or not pending.accepted:
@@ -420,8 +433,7 @@ class RomControlHooks:
 
         if not pending.accepted:
             if pending.input_domain == _ControlDomain.OVERWORLD and pressed & pending.button_mask:
-                pending.accepted = True
-                self._current_boundary = None
+                self._accept_button(pending)
             return
 
         if overworld_ready and not held & pending.button_mask:
@@ -436,7 +448,7 @@ class RomControlHooks:
         if pending is None or pending.input_domain != domain or pending.accepted:
             return
         if input_state & pending.button_mask:
-            pending.accepted = True
+            self._accept_button(pending)
 
     def _observe_ready(self, domain: _ControlDomain, boundary: ControlBoundary) -> None:
         """Track and, when applicable, complete a prepared input boundary."""
@@ -476,8 +488,7 @@ class RomControlHooks:
                 self._pyboy.memory[_JOY_PRESSED_ADDRESS] | self._pyboy.memory[_MENU_INPUT_ADDRESS]
             )
             if input_state & pending.button_mask:
-                pending.accepted = True
-                self._current_boundary = None
+                self._accept_button(pending)
             return
 
         input_released = not self._pyboy.memory[_JOY_HELD_ADDRESS] & pending.button_mask
@@ -498,6 +509,11 @@ class RomControlHooks:
             and self._pyboy.memory[_WALK_COUNTER_ADDRESS] == 0
         ):
             self._step_completed_this_tick = True
+
+    def _accept_button(self, pending: _PendingOperation) -> None:
+        """Record that the ROM consumed an injected button press."""
+        pending.accepted = True
+        self._current_boundary = None
 
     def _is_overworld_ready(self) -> bool:
         mem = self._pyboy.memory

--- a/emulator/rom_hooks/control.py
+++ b/emulator/rom_hooks/control.py
@@ -57,6 +57,7 @@ class _PendingOperation:
     required_boundary: ControlBoundary | None = None
     observe_steps: bool = False
     accepted: bool = False
+    handoff_requested: bool = False
     release_scheduled: bool = False
     render_ready_frame: int | None = None
     step_observations: list[GameState] = field(default_factory=list)
@@ -334,19 +335,31 @@ class RomControlHooks:
                 pending.step_observations.append(step_observation)
             self._step_completed_this_tick = False
 
+        self._request_handoff_if_overworld_control_lost()
         self._observe_immediate_input()
 
         pending = self._pending
         if (
             pending is not None
             and pending.button is not None
-            and pending.accepted
+            and (pending.accepted or pending.handoff_requested)
             and not pending.release_scheduled
         ):
             # Hook callbacks run inside tick(), where an immediate PyBoy release would be discarded
             # by that tick's event cleanup. Queue it here, between ticks, for the next frame.
             self._pyboy.button_release(pending.button)
             pending.release_scheduled = True
+
+        if pending is not None and pending.handoff_requested:
+            if (
+                pending.button is not None
+                and self._pyboy.memory[_JOY_HELD_ADDRESS] & pending.button_mask
+            ):
+                return
+            self._results.publish_handoff(pending.operation_id)
+            self._completed_boundary = None
+            self._pending = None
+            return
 
         if self._completed_boundary is None:
             return
@@ -369,6 +382,9 @@ class RomControlHooks:
 
     def observe_text_event(self, kind: TextEventKind) -> None:
         """Track text-driven control domains without consuming their event journal."""
+        if kind not in {TextEventKind.PAGE_COMPLETED, TextEventKind.AUTOMATIC_SCROLL}:
+            self._request_handoff_for_unaccepted_button()
+
         if kind == TextEventKind.INPUT_REQUIRED:
             self._current_domain = _ControlDomain.IMMEDIATE
             self._observe_ready_boundary(ControlBoundary.TEXT_INPUT_READY)
@@ -432,8 +448,7 @@ class RomControlHooks:
             return
 
         if not pending.accepted:
-            if pending.input_domain == _ControlDomain.OVERWORLD and pressed & pending.button_mask:
-                self._accept_button(pending)
+            self._observe_unaccepted_overworld_button(pending, pressed)
             return
 
         if overworld_ready and not held & pending.button_mask:
@@ -461,6 +476,9 @@ class RomControlHooks:
         pending = self._pending
         if pending is None:
             return
+        if not pending.accepted and pending.button is not None and pending.input_domain != domain:
+            self._request_handoff_for_unaccepted_button()
+            return
         if pending.button is None:
             if held == 0:
                 self._complete(boundary)
@@ -476,6 +494,7 @@ class RomControlHooks:
         pending = self._pending
         if (
             pending is None
+            or pending.handoff_requested
             or pending.required_boundary is not None
             or pending.input_domain != _ControlDomain.IMMEDIATE
             or self._completed_boundary is not None
@@ -514,6 +533,34 @@ class RomControlHooks:
         """Record that the ROM consumed an injected button press."""
         pending.accepted = True
         self._current_boundary = None
+
+    def _observe_unaccepted_overworld_button(
+        self,
+        pending: _PendingOperation,
+        pressed: int,
+    ) -> None:
+        """Accept overworld input or hand it off after another domain takes control."""
+        if pending.input_domain != _ControlDomain.OVERWORLD:
+            self._request_handoff_for_unaccepted_button()
+        elif pressed & pending.button_mask:
+            self._accept_button(pending)
+
+    def _request_handoff_for_unaccepted_button(self) -> None:
+        """Cancel a held button when the ROM changes domains before consuming it."""
+        pending = self._pending
+        if pending is not None and pending.button is not None and not pending.accepted:
+            pending.handoff_requested = True
+
+    def _request_handoff_if_overworld_control_lost(self) -> None:
+        """Cancel unaccepted overworld input as soon as scripted control takes over."""
+        pending = self._pending
+        if (
+            pending is not None
+            and pending.input_domain == _ControlDomain.OVERWORLD
+            and not pending.accepted
+            and not self._is_overworld_ready()
+        ):
+            pending.handoff_requested = True
 
     def _is_overworld_ready(self) -> bool:
         mem = self._pyboy.memory

--- a/emulator/tests/unit/test_text_events.py
+++ b/emulator/tests/unit/test_text_events.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from common.enums import Button
 from emulator.control_events import ControlBoundary, ControlResult
 from emulator.text_events import (
     DialogPage,
@@ -12,6 +13,7 @@ from emulator.text_events import (
     TextEventJournal,
     TextEventKind,
     TextEventReducer,
+    TextEventSnapshot,
     drive_standard_dialog,
 )
 
@@ -110,7 +112,7 @@ async def test_dialog_driver_stops_when_an_initial_menu_is_replaced() -> None:
             emulator,
             reducer=TextEventReducer(),
             stop_on=frozenset({TextEventKind.MENU_OPENED}),
-            initial_events=events,
+            initial_snapshot=TextEventSnapshot(events=events),
         )
         == ""
     )
@@ -129,11 +131,37 @@ async def test_dialog_driver_waits_through_a_transition_marker() -> None:
             emulator,
             reducer=TextEventReducer(),
             stop_on=frozenset({TextEventKind.INTERACTION_CLOSED}),
-            initial_events=(_event(1, TextEventKind.INTERACTION_CLOSED),),
+            initial_snapshot=TextEventSnapshot(
+                events=(_event(1, TextEventKind.INTERACTION_CLOSED),)
+            ),
         )
         == ""
     )
     emulator.wait_until_ready.assert_awaited_once_with()
+
+
+@pytest.mark.unit
+async def test_dialog_driver_uses_live_boundary_after_input_event_was_claimed() -> None:
+    """Advance text when the preceding domain already claimed its input event."""
+    emulator = MagicMock()
+    emulator.wait_for_text_events = AsyncMock(
+        return_value=(_event(1, TextEventKind.INTERACTION_CLOSED),)
+    )
+    emulator.pulse_button = AsyncMock()
+    emulator.wait_until_ready = AsyncMock(
+        return_value=ControlResult(boundary=ControlBoundary.OVERWORLD_READY)
+    )
+
+    await drive_standard_dialog(
+        emulator,
+        reducer=TextEventReducer(),
+        stop_on=frozenset({TextEventKind.INTERACTION_CLOSED}),
+        initial_snapshot=TextEventSnapshot(
+            boundary=ControlBoundary.TEXT_INPUT_READY,
+        ),
+    )
+
+    emulator.pulse_button.assert_awaited_once_with(Button.A)
 
 
 @pytest.mark.unit
@@ -150,9 +178,11 @@ async def test_dialog_driver_hands_off_when_input_opens_a_custom_interface() -> 
         emulator,
         reducer=TextEventReducer(),
         stop_on=frozenset({TextEventKind.INTERACTION_CLOSED}),
-        initial_events=(
-            _event(1, TextEventKind.PAGE_COMPLETED, page),
-            _event(2, TextEventKind.INPUT_RESOLVED),
+        initial_snapshot=TextEventSnapshot(
+            events=(
+                _event(1, TextEventKind.PAGE_COMPLETED, page),
+                _event(2, TextEventKind.INPUT_RESOLVED),
+            ),
         ),
     )
 

--- a/emulator/text_events.py
+++ b/emulator/text_events.py
@@ -49,6 +49,14 @@ class TextEvent:
     page: DialogPage | None = None
 
 
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TextEventSnapshot:
+    """Unread text events and the rendered control boundary observed with them."""
+
+    events: tuple[TextEvent, ...] = ()
+    boundary: ControlBoundary | None = None
+
+
 class TextEventReducer:
     """Reduce ordered text events while retaining the active dialog page."""
 
@@ -245,45 +253,51 @@ async def drive_standard_dialog(
     *,
     reducer: TextEventReducer,
     stop_on: frozenset[TextEventKind],
-    initial_events: tuple[TextEvent, ...] = (),
+    initial_snapshot: TextEventSnapshot | None = None,
     before_input: Callable[[], Awaitable[None]] | None = None,
 ) -> str:
     """Advance explicit dialog waits until the requested ROM boundary."""
+    initial_snapshot = initial_snapshot or TextEventSnapshot()
     events: list[TextEvent] = []
-    batch = initial_events
+    batch = initial_snapshot.events
     initial_batch = bool(batch)
-    control = _DialogControlState(waiting_for_initial_menu_exit=initial_batch)
+    control = _DialogControlState(
+        input_required=(
+            not batch and initial_snapshot.boundary == ControlBoundary.TEXT_INPUT_READY
+        ),
+        waiting_for_initial_menu_exit=initial_batch,
+    )
 
     while True:
-        if not batch:
-            batch = await emulator.wait_for_text_events()
-        if not batch:
-            raise RuntimeError("Emulator stopped before dialog reached a semantic boundary.")
-        events.extend(batch)
+        if batch:
+            events.extend(batch)
 
-        reached_boundary = control.apply(
-            batch,
-            initial_batch=initial_batch,
-            stop_on=stop_on,
-        )
-        initial_batch = False
+            reached_boundary = control.apply(
+                batch,
+                initial_batch=initial_batch,
+                stop_on=stop_on,
+            )
+            initial_batch = False
 
-        if reached_boundary:
-            if control.menu_open and TextEventKind.MENU_OPENED in stop_on:
-                await emulator.wait_for_menu_ready()
-            else:
-                await emulator.wait_until_ready()
-            return reducer.reduce(events)
-
-        if any(event.kind == TextEventKind.INPUT_RESOLVED for event in batch):
-            boundary = (await emulator.wait_until_ready()).boundary
-            if boundary != ControlBoundary.TEXT_INPUT_READY:
-                events.extend(emulator.drain_text_events())
+            if reached_boundary:
+                if control.menu_open and TextEventKind.MENU_OPENED in stop_on:
+                    await emulator.wait_for_menu_ready()
+                else:
+                    await emulator.wait_until_ready()
                 return reducer.reduce(events)
+
+            if any(event.kind == TextEventKind.INPUT_RESOLVED for event in batch):
+                boundary = (await emulator.wait_until_ready()).boundary
+                if boundary != ControlBoundary.TEXT_INPUT_READY:
+                    events.extend(emulator.drain_text_events())
+                    return reducer.reduce(events)
 
         if control.input_required and not control.input_sent:
             if before_input is not None:
                 await before_input()
             await emulator.pulse_button(Button.A)
             control.input_sent = True
-        batch = ()
+
+        batch = await emulator.wait_for_text_events()
+        if not batch:
+            raise RuntimeError("Emulator stopped before dialog reached a semantic boundary.")

--- a/memory/goals.py
+++ b/memory/goals.py
@@ -9,6 +9,7 @@ class Goal:
 
     goal: str
     is_primary: bool
+    updated_at_iteration: int
 
 
 @dataclass(slots=True, kw_only=True)

--- a/memory/goals.py
+++ b/memory/goals.py
@@ -2,13 +2,14 @@
 
 from dataclasses import dataclass, field
 
+MAX_GOALS = 4
+
 
 @dataclass(slots=True, kw_only=True)
 class Goal:
     """A goal for the agent."""
 
     goal: str
-    is_primary: bool
     updated_at_iteration: int
 
 
@@ -23,7 +24,6 @@ class Goals:
         for goal in goals:
             goal.goal = goal.goal.strip()
             self.goals.append(goal)
-        self.goals = sorted(self.goals, key=lambda g: not g.is_primary)
 
     def remove(self, *indices: int) -> None:
         """Remove goals from the list."""

--- a/streaming/background/assets/technical-difficulties.svg
+++ b/streaming/background/assets/technical-difficulties.svg
@@ -44,10 +44,10 @@
 
   <!-- Main technical difficulties text -->
   <g transform="translate(960, 400)">
-    <text x="0" y="0" text-anchor="middle" font-family="Orbitron, monospace" font-size="72" font-weight="900" fill="#e6f1ff" filter="url(#glow)">
+    <text x="0" y="0" text-anchor="middle" font-family="Inter, sans-serif" font-size="72" font-weight="800" fill="#e6f1ff" filter="url(#glow)">
       TECHNICAL DIFFICULTIES
     </text>
-    <text x="0" y="80" text-anchor="middle" font-family="Roboto Mono, monospace" font-size="32" font-weight="400" fill="#00d4ff">
+    <text x="0" y="80" text-anchor="middle" font-family="JetBrains Mono, monospace" font-size="32" font-weight="400" fill="#00d4ff">
       We'll be right back...
     </text>
   </g>

--- a/streaming/background/index.html
+++ b/streaming/background/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link
-        href="https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@400;700&family=Orbitron:wght@400;700;900&display=swap"
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
         rel="stylesheet">
 </head>
 

--- a/streaming/background/style.css
+++ b/streaming/background/style.css
@@ -1,11 +1,14 @@
 :root {
     --main-bg-color: #0f1923;
     --panel-bg-color: rgba(10, 25, 47, 0.7);
-    --border-color: #00d4ff;
+    --accent-color: #00d4ff;
+    --border-color: #0c89a1;
+    --empty-border-color: #126276;
     --text-color: #e6f1ff;
     --highlight-color: #ffd700;
-    --font-body: 'Roboto Mono', monospace;
-    --font-title: 'Orbitron', sans-serif;
+    --font-body: 'Inter', sans-serif;
+    --font-mono: 'JetBrains Mono', monospace;
+    --font-title: 'Inter', sans-serif;
 }
 
 * {
@@ -53,7 +56,7 @@ body {
 .title-bar {
     grid-area: header;
     text-align: center;
-    border-bottom: 2px solid var(--border-color);
+    border-bottom: 2px solid var(--accent-color);
     padding: 8px 0;
     margin-bottom: 0;
     display: flex;
@@ -65,10 +68,10 @@ body {
 .title-bar h1 {
     font-family: var(--font-title);
     font-size: 42px;
-    font-weight: 900;
+    font-weight: 800;
     letter-spacing: 3px;
     color: var(--text-color);
-    text-shadow: 0 0 15px var(--border-color);
+    text-shadow: 0 0 8px rgba(0, 212, 255, 0.55);
     margin: 0;
     line-height: 1;
 }
@@ -104,13 +107,13 @@ body {
 
 .info-item .label {
     font-size: 15px;
-    color: var(--border-color);
+    color: var(--accent-color);
     letter-spacing: 1px;
     margin-bottom: 3px;
 }
 
 .info-item .value {
-    font-family: var(--font-title);
+    font-family: var(--font-mono);
     font-size: 24px;
     font-weight: 700;
 }
@@ -144,7 +147,7 @@ body {
 .log-panel h2 {
     text-align: center;
     padding-bottom: 10px;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--accent-color);
     flex-shrink: 0;
 }
 
@@ -157,6 +160,7 @@ body {
     flex-grow: 1;
     overflow-y: auto;
     padding-top: 10px;
+    font-family: var(--font-mono);
     font-size: 18px;
     scrollbar-width: none;
     -ms-overflow-style: none;
@@ -180,13 +184,14 @@ body {
 .goals-panel h2 {
     text-align: center;
     padding-bottom: 10px;
-    border-bottom: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--accent-color);
     flex-shrink: 0;
 }
 
 #goals {
     flex-grow: 1;
     padding-top: 10px;
+    font-family: var(--font-mono);
     list-style-type: none;
     padding-left: 0;
     overflow-y: auto;
@@ -218,14 +223,14 @@ body {
 .game-window-placeholder {
     width: 580px;
     aspect-ratio: 10/9;
-    border: 2px dashed var(--border-color);
+    border: 2px dashed var(--accent-color);
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    color: var(--border-color);
+    color: var(--accent-color);
     opacity: 0.6;
-    box-shadow: 0 0 8px var(--border-color), 0 0 16px var(--border-color);
+    box-shadow: 0 0 10px rgba(0, 212, 255, 0.45);
     border-radius: 4px;
 }
 
@@ -274,7 +279,7 @@ body {
 
 .pokemon-card.empty {
     background: linear-gradient(145deg, #0a0a0a, #1a1a1a);
-    border: 1px dashed var(--border-color);
+    border: 1px dashed var(--empty-border-color);
     opacity: 0.7;
 }
 
@@ -324,11 +329,11 @@ body {
 
 .pokemon-species {
     font-size: 14px;
-    color: var(--border-color);
+    color: var(--accent-color);
 }
 
 .pokemon-level {
-    color: var(--border-color);
+    color: var(--accent-color);
     font-size: 14px;
 }
 

--- a/streaming/schemas.py
+++ b/streaming/schemas.py
@@ -99,9 +99,6 @@ class GameStateView(BaseModel):
             play_time_seconds=game_state.player.play_time_seconds,
             badges=[str(badge) for badge in game_state.player.badges],
             party=pokemon,
-            goals=[
-                f"{'Primary goal' if goal.is_primary else 'Other goal'}: {goal.goal}"
-                for goal in agent_state.goals.goals
-            ],
+            goals=[goal.goal for goal in agent_state.goals.goals],
             log=log,
         )

--- a/streaming/schemas.py
+++ b/streaming/schemas.py
@@ -93,7 +93,7 @@ class GameStateView(BaseModel):
             iteration=agent_state.iteration,
             money=game_state.player.money,
             pokedex_seen=game_state.player.pokedex_seen,
-            pokedex_caught=game_state.player.pokedex_caught,
+            pokedex_caught=len(game_state.player.pokedex_caught),
             total_tokens=agent_state.total_tokens,
             total_cost=agent_state.total_cost,
             play_time_seconds=game_state.player.play_time_seconds,


### PR DESCRIPTION
## Summary

This PR collects gameplay, navigation, prompt, emulator-control, and streaming-overlay refinements developed from the active playtesting.

- Improves the agent’s spatial context and overworld navigation.
- Makes button input and gameplay-domain transitions deterministic.
- Simplifies goals and clarifies general gameplay priorities.
- Exposes useful Pokédex and inventory context.
- Refines the streaming overlay and cost documentation.

## Changes

### Overworld navigation

- Display only the player’s currently reachable map region, cropped to its rectangular bounding box while preserving global coordinates.
- Mark inaccessible coordinates inside the crop separately from unexplored tiles.
- Limit warps and signs to the current region while retaining visible sprites needed for counter interactions.
- Reveal unvisited Pokémon Center, Gym, and Poké Mart destinations because their exteriors identify them onscreen.
- Include source and destination coordinates in map-transition results.
- Share traversal algorithms between navigation and derived map views.
- Clarify directional input, warp activation, exploration, NPC interaction, and item collection.
- Rename overworld Poké Ball sprites to Item Ball.
- Remove the misleading explored-map percentage.
- Document a future semantic warp-routing graph.

### Emulator control

- Hold buttons until the ROM accepts them instead of relying on fixed-duration pulses.
- Release accepted or orphaned inputs at the correct rendered boundary.
- Preserve text readiness and pending dialog across gameplay-handler transitions.
- Cancel inputs when another gameplay domain takes control before acceptance.
- Return expected control handoffs to the dispatcher without recording failed tool spans.
- Release restored host inputs when loading save states.
- Prevent unrelated random encounters from making the Seafoam Sokoban integration test nondeterministic.

### Goals and prompts

- Replace primary and secondary goals with a flat list of up to four independent goals.
- Record and display the iteration when each goal was last updated.
- Encourage a useful mixture of progression, team, resource, and investigative goals without treating routine movement as a goal.
- Ground goals in observed context rather than inferred future game knowledge.
- Scope goal-management instructions to the overworld agent where the tools are available.
- Require plain-text responses.
- Clarify that the level cap prevents experience gain rather than Pokémon use.
- Establish collecting eight badges and becoming Champion as the overall objective while encouraging timely team building rather than exhaustive catching.
- Show explicit context when the inventory or goal list is empty.

### Battles and Pokédex

- Parse the Pokédex caught flags into the specific set of registered species.
- Tell the agent when a wild or Safari Zone opponent has already been caught.
- Preserve the aggregate caught count used by the streaming overlay.

### Streaming overlay

- Replace Orbitron and Roboto Mono with Inter and JetBrains Mono.
- Retain monospace typography for the activity log and goals.
- Refine cyan accents, borders, empty-party slots, and glow intensity.
- Update the technical-difficulties asset to match.

### Documentation

- Express estimated hourly cost growth in hours played while retaining the underlying logarithmic iteration-growth explanation.
- Update workflow documentation for flattened goals and current overworld behavior.